### PR TITLE
Restructure README: proxy as primary feature, clarify MCP limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ LLMs process personal data in ways users can't control: training pipelines, prov
 ## Security Layers
 
 ```
-                         YOUR MACHINE                          │  PROVIDER
-                                                               │
-  ┌─────────┐         ┌──────────────────────────────────┐     │    ┌──────────┐
+                         YOUR MACHINE                           │  PROVIDER
+                                                                │
+  ┌──────────┐         ┌──────────────────────────────────┐     │    ┌──────────┐
   │  User /  │         │            DAM Proxy             │     │    │          │
   │  App     │         │                                  │     │    │   LLM    │
   │          │─────────┤►  1. INTERCEPT                   │     │    │ Provider │
@@ -23,7 +23,7 @@ LLMs process personal data in ways users can't control: training pipelines, prov
   │  at 555- │         │   Regex pipeline finds PII       │     │    │          │
   │  1234"   │         │                                  │     │    │          │
   │          │         │►  3. ENCRYPT + VAULT             │     │    │          │
-  │          │         │   AES-256-GCM per value ──► 🔒   │     │    │          │
+  │          │         │   AES-256-GCM per value ──► 🔒  │     │    │          │
   │          │         │                                  │     │    │          │
   │          │         │►  4. REPLACE                     │     │    │          │
   │          │         │   john@acme.co → [email:a3f71bc9]│     │    │          │
@@ -37,10 +37,10 @@ LLMs process personal data in ways users can't control: training pipelines, prov
   │  real    │  values │                                  │     │    │          │
   │  values  │         │►  6. AUDIT                       │     │    │          │
   │          │         │   SHA-256 hash-chained log       │     │    │          │
-  └─────────┘         └──────────────────────────────────┘     │    └──────────┘
-                                                               │
-                       Everything stays local.                 │  PII never leaves
-                       Vault, keys, audit — on your machine.   │  your machine.
+  └──────────┘         └──────────────────────────────────┘     │    └──────────┘
+                                                                │
+                       Everything stays local.                  │  PII never leaves
+                       Vault, keys, audit — on your machine.    │  your machine.
 ```
 
 The proxy operates transparently: no code changes needed in your application. Point your API client at DAM instead of the provider, and PII is intercepted automatically.


### PR DESCRIPTION
The previous README presented MCP as the primary integration and
instructed the LLM to call dam_scan on user input — but since MCP
tools are invoked by the LLM, it has already seen the raw PII by
then, undermining the core security promise.

- Lead with HTTP proxy as the primary integration path
- Add security layer diagram showing the machine boundary
- Reframe MCP as supplementary agent tools (vault ops, external
  data scanning, consent management) with an honest security caveat
- Add Proxy vs MCP comparison table under Security Model
- Remove the misleading SERVER_INSTRUCTIONS quote
- Reorder Quick Start to start with proxy setup

https://claude.ai/code/session_01L1M2Zt823RSy8Bq5thwQbs