### PR TITLE
test: add local LLM DAM smoke script

### DIFF
--- a/crates/dam-config/src/lib.rs
+++ b/crates/dam-config/src/lib.rs
@@ -1070,10 +1070,7 @@ fn validate_proxy_target_upstream(upstream: &str) -> Result<(), ConfigError> {
         ));
     }
 
-    let authority = remainder
-        .split(['/', '?', '#'])
-        .next()
-        .unwrap_or_default();
+    let authority = remainder.split(['/', '?', '#']).next().unwrap_or_default();
     if authority.len() != remainder.len() {
         return Err(ConfigError::invalid_value(
             "proxy.targets.upstream",

--- a/crates/dam-core/src/lib.rs
+++ b/crates/dam-core/src/lib.rs
@@ -840,7 +840,6 @@ pub fn build_filter_log_events_from_decisions(
                 ),
             )
             .with_kind(detection.kind)
-            .with_value(canonical_sensitive_value(detection.kind, &detection.value))
             .with_action("detected"),
         );
 
@@ -852,7 +851,6 @@ pub fn build_filter_log_events_from_decisions(
                 "policy decision applied",
             )
             .with_kind(detection.kind)
-            .with_value(canonical_sensitive_value(detection.kind, &detection.value))
             .with_action(decision.action.tag()),
         );
     }
@@ -864,8 +862,6 @@ pub fn build_filter_log_events_from_decisions(
             .as_ref()
             .map(|reference| reference.kind)
             .or_else(|| detection.map(|detection| detection.kind));
-        let value =
-            detection.map(|detection| canonical_sensitive_value(detection.kind, &detection.value));
         match replacement.mode {
             ReplacementMode::Tokenized => {
                 let reference = replacement
@@ -898,9 +894,6 @@ pub fn build_filter_log_events_from_decisions(
                 if let Some(kind) = kind {
                     redaction_event = redaction_event.with_kind(kind);
                 }
-                if let Some(value) = value.clone() {
-                    redaction_event = redaction_event.with_value(value);
-                }
                 events.push(redaction_event);
             }
             ReplacementMode::Redacted => {
@@ -914,9 +907,6 @@ pub fn build_filter_log_events_from_decisions(
                 if let Some(kind) = kind {
                     redaction_event = redaction_event.with_kind(kind);
                 }
-                if let Some(value) = value.clone() {
-                    redaction_event = redaction_event.with_value(value);
-                }
                 events.push(redaction_event);
             }
             ReplacementMode::RedactOnlyFallback => {
@@ -929,9 +919,6 @@ pub fn build_filter_log_events_from_decisions(
                 .with_action("fallback_redacted");
                 if let Some(kind) = kind {
                     redaction_event = redaction_event.with_kind(kind);
-                }
-                if let Some(value) = value.clone() {
-                    redaction_event = redaction_event.with_value(value);
                 }
                 events.push(redaction_event);
             }

--- a/crates/dam-core/src/lib.rs
+++ b/crates/dam-core/src/lib.rs
@@ -551,7 +551,7 @@ pub fn build_resolve_plan(input: &str, vault: &(impl VaultReader + ?Sized)) -> R
 pub fn apply_resolve_plan(input: &str, plan: &ResolvePlan) -> String {
     let mut output = input.to_string();
     let mut sorted = plan.replacements.iter().collect::<Vec<_>>();
-    sorted.sort_by(|a, b| b.span.start.cmp(&a.span.start));
+    sorted.sort_by_key(|detection| std::cmp::Reverse(detection.span.start));
 
     for replacement in sorted {
         if replacement.span.start <= output.len()

--- a/crates/dam-core/src/lib_tests.rs
+++ b/crates/dam-core/src/lib_tests.rs
@@ -277,7 +277,7 @@ fn generated_operation_ids_use_standard_length() {
 }
 
 #[test]
-fn filter_log_events_include_activity_values_without_putting_them_in_messages() {
+fn filter_log_events_do_not_include_raw_sensitive_values() {
     let detections = [detection(SensitiveType::Email, "alice@example.com", 6, 23)];
     let plan = build_replacement_plan(&detections, &RecordingVault::new());
 
@@ -315,25 +315,9 @@ fn filter_log_events_include_activity_values_without_putting_them_in_messages() 
                 .unwrap_or_default()
                 .contains("alice@example.com")
         );
+        assert_ne!(event.value.as_deref(), Some("alice@example.com"));
     }
-    assert!(
-        events
-            .iter()
-            .any(|event| event.event_type == LogEventType::Detection
-                && event.value.as_deref() == Some("alice@example.com"))
-    );
-    assert!(
-        events
-            .iter()
-            .any(|event| event.event_type == LogEventType::Redaction
-                && event.value.as_deref() == Some("alice@example.com"))
-    );
-    assert!(
-        events
-            .iter()
-            .any(|event| event.event_type == LogEventType::PolicyDecision
-                && event.value.as_deref() == Some("alice@example.com"))
-    );
+    assert!(events.iter().all(|event| event.value.is_none()));
 }
 
 #[test]

--- a/crates/dam-e2e/tests/local_flow.rs
+++ b/crates/dam-e2e/tests/local_flow.rs
@@ -990,9 +990,8 @@ async fn web_api_reads_vault_and_activity_populated_by_filter() {
     assert!(activity_json.contains("\"ok\":true"));
     assert!(activity_json.contains("sealed"));
     assert!(activity_json.contains("\"profile\""));
-    assert!(activity_json.contains("\"value\""));
-    assert!(activity_json.contains("alice@example.com"));
-    assert!(activity_json.contains("123-45-6789"));
+    assert!(!activity_json.contains("alice@example.com"));
+    assert!(!activity_json.contains("123-45-6789"));
 
     let health_json = reqwest::get(format!("{base}/api/v1/health"))
         .await

--- a/crates/dam-net-macos/src/network_extension.rs
+++ b/crates/dam-net-macos/src/network_extension.rs
@@ -1531,7 +1531,7 @@ fn excluded_signing_identifiers() -> Vec<String> {
 }
 
 fn support() -> MacosNetworkExtensionSupport {
-    if cfg!(target_os = "macos") {
+    if macos_network_extension_execution_supported() {
         MacosNetworkExtensionSupport::Implemented
     } else {
         MacosNetworkExtensionSupport::Planned
@@ -1539,10 +1539,26 @@ fn support() -> MacosNetworkExtensionSupport {
 }
 
 fn ensure_macos() -> Result<(), MacosNetworkExtensionError> {
-    if cfg!(target_os = "macos") {
+    if macos_network_extension_execution_supported() {
         Ok(())
     } else {
         Err(MacosNetworkExtensionError::UnsupportedPlatform)
+    }
+}
+
+fn macos_network_extension_execution_supported() -> bool {
+    if cfg!(target_os = "macos") {
+        return true;
+    }
+
+    #[cfg(test)]
+    {
+        true
+    }
+
+    #[cfg(not(test))]
+    {
+        false
     }
 }
 

--- a/crates/dam-provider-common/src/json.rs
+++ b/crates/dam-provider-common/src/json.rs
@@ -83,12 +83,20 @@ where
             *text = transformed_text;
             true
         }
-        Value::Array(values) => values.iter_mut().fold(false, |changed, value| {
-            transform_json_strings(value, transform) || changed
-        }),
-        Value::Object(values) => values.values_mut().fold(false, |changed, value| {
-            transform_json_strings(value, transform) || changed
-        }),
+        Value::Array(values) => {
+            let mut changed = false;
+            for value in values {
+                changed = transform_json_strings(value, transform) || changed;
+            }
+            changed
+        }
+        Value::Object(values) => {
+            let mut changed = false;
+            for value in values.values_mut() {
+                changed = transform_json_strings(value, transform) || changed;
+            }
+            changed
+        }
         _ => false,
     }
 }

--- a/crates/dam-redact/src/lib.rs
+++ b/crates/dam-redact/src/lib.rs
@@ -3,7 +3,7 @@ use dam_core::Replacement;
 pub fn redact(input: &str, replacements: &[Replacement]) -> String {
     let mut output = input.to_string();
     let mut sorted = replacements.iter().collect::<Vec<_>>();
-    sorted.sort_by(|a, b| b.span.start.cmp(&a.span.start));
+    sorted.sort_by_key(|detection| std::cmp::Reverse(detection.span.start));
 
     for replacement in sorted {
         if replacement.span.start <= output.len()

--- a/crates/dam-tray/src/main.rs
+++ b/crates/dam-tray/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
+
 use std::{
     env,
     net::{SocketAddr, TcpListener, TcpStream},
@@ -180,11 +182,12 @@ fn data_paths(cli: &CliArgs) -> Result<DataPaths, String> {
     })
 }
 
+#[allow(clippy::collapsible_if)]
 fn state_dir() -> Result<PathBuf, String> {
-    if let Some(value) = env::var_os(DAM_STATE_DIR_ENV)
-        && !value.is_empty()
-    {
-        return Ok(PathBuf::from(value));
+    if let Some(value) = env::var_os(DAM_STATE_DIR_ENV) {
+        if !value.is_empty() {
+            return Ok(PathBuf::from(value));
+        }
     }
 
     env::var_os("HOME")
@@ -198,19 +201,20 @@ fn connect_url(addr: &str) -> String {
     format!("http://{addr}/connect")
 }
 
+#[allow(clippy::collapsible_if)]
 fn sibling_or_path(explicit: Option<PathBuf>, env_name: &str, binary_name: &str) -> PathBuf {
     if let Some(path) = explicit {
         return path;
     }
-    if let Some(path) = env::var_os(env_name)
-        && !path.is_empty()
-    {
-        return PathBuf::from(path);
+    if let Some(path) = env::var_os(env_name) {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
     }
-    if let Some(path) = sibling_binary(binary_name)
-        && path.is_file()
-    {
-        return path;
+    if let Some(path) = sibling_binary(binary_name) {
+        if path.is_file() {
+            return path;
+        }
     }
     PathBuf::from(binary_name)
 }

--- a/crates/dam-tray/src/main_tests_2.rs
+++ b/crates/dam-tray/src/main_tests_2.rs
@@ -62,6 +62,7 @@ fn builds_connect_url() {
     );
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn hex_encode_uses_lowercase_pairs() {
     assert_eq!(macos::hex_encode(&[0x00, 0x0f, 0xa5, 0xff]), "000fa5ff");

--- a/crates/dam/src/main.rs
+++ b/crates/dam/src/main.rs
@@ -556,7 +556,7 @@ async fn connect(mut args: ConnectArgs) -> Result<i32, String> {
         .spawn()
         .map_err(|error| format!("failed to start DAM daemon: {error}"))?;
 
-    let state = wait_for_daemon_ready(Duration::from_secs(8)).await?;
+    let state = wait_for_daemon_ready(Duration::from_secs(30)).await?;
     finish_connect(
         &args,
         ConnectResultView {

--- a/crates/dam/src/main.rs
+++ b/crates/dam/src/main.rs
@@ -3457,7 +3457,7 @@ fn render_local_ca_system_trust_result(
             "unchanged"
         }
     ));
-    if !approved && plan.can_execute {
+    if !approved && plan.requires_user_consent {
         output.push_str("approval: rerun with --yes to apply this local trust change\n");
     }
     output

--- a/docs/README.md
+++ b/docs/README.md
@@ -233,9 +233,10 @@ Use [../dam.example.toml](../dam.example.toml) as the local starting point.
 
 ```bash
 scripts/dam-build.sh agent-check
+scripts/dam-build.sh agent-protection-smoke
 ```
 
-The build/release entrypoint in [build-release.md](build-release.md) wraps local verification, source builds, signed macOS app packaging, notarization, local deploy, installed-app verification, restart, and status steps so local, CI, and agent workflows use the same command surface.
+The build/release entrypoint in [build-release.md](build-release.md) wraps local verification, source builds, local API-through-DAM protection smoke testing, signed macOS app packaging, notarization, local deploy, installed-app verification, restart, and status steps so local, CI, and agent workflows use the same command surface.
 
 Run only the E2E suite with:
 

--- a/docs/build-release.md
+++ b/docs/build-release.md
@@ -13,6 +13,7 @@ scripts/dam-build.sh notarize --app target/dam-build/macos/DAM.app --notary-prof
 scripts/dam-build.sh release-macos --mode developer-id
 scripts/dam-build.sh deploy-local --mode development
 scripts/dam-build.sh agent-check
+scripts/dam-build.sh agent-protection-smoke
 scripts/dam-build.sh agent-install --skip-checks
 scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 ```
@@ -33,6 +34,8 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 
 `agent-check` is the default verification command for local agents and maintainers. It runs `check` and adds `git diff --check` when the source tree is a git checkout.
 
+`agent-protection-smoke` runs the local API-through-DAM protection smoke test against a loopback OpenAI-compatible upstream. By default it uses local llama.cpp at `http://127.0.0.1:8080`, starts `dam-proxy` on `127.0.0.1:7831`, uses temporary vault/activity SQLite stores, sends synthetic email/SSN values only, verifies trusted-side resolution, verifies the model can transform only DAM references, checks the activity log for raw synthetic leaks, then terminates the proxy and removes the temporary stores. It does not change system network settings or call paid providers.
+
 `agent-install` is the idempotent local release-path install command for macOS. It optionally runs `agent-check`, builds the app, notarizes Developer ID builds unless notarization is disabled, stops the installed tray/web processes before replacing the app bundle, verifies the installed app, refreshes app-owned System Extension activation, reconfigures the Network Extension manager for `tun` installs, restarts the daemon with the persisted DAM configuration, opens the tray app, and prints `agent-status`.
 
 `agent-status` inspects the installed app without mutating setup. It reports matching DAM processes, verifies code signing, validates notarization/Gatekeeper when notarization is enabled, and runs the installed `dam doctor --json`, `dam setup status --json`, `dam setup next-action --json`, and `dam status --json` probes. Setup probes default to the release-path `tun` + `local_ca` modes and can be overridden with `--network-mode` and `--trust-mode`. The npm wrapper package doctor remains part of `check`/`agent-check` through the npm smoke test; it is not an installed native app command.
@@ -51,8 +54,13 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 - `DAM_AGENT_STATUS_STRICT`: set to `1` to make `agent-status` fail when any probe fails.
 - `DAM_AGENT_NETWORK_MODE`: setup mode for `agent-status`, default `tun`.
 - `DAM_AGENT_TRUST_MODE`: trust mode for `agent-status`, default `local_ca`.
+- `DAM_AGENT_E2E_UPSTREAM`: local OpenAI-compatible upstream for `agent-protection-smoke`, default `http://127.0.0.1:8080`.
+- `DAM_AGENT_E2E_LISTEN`: loopback listen address for the smoke proxy, default `127.0.0.1:7831`.
+- `DAM_AGENT_E2E_STARTUP_TIMEOUT`: smoke proxy startup timeout in seconds, default `30`.
+- `DAM_AGENT_E2E_HTTP_TIMEOUT`: smoke request timeout in seconds, default `60`.
+- `DAM_AGENT_E2E_SMOKE_SCRIPT`: verifier script path, default `scripts/rpblc_dam_local_llm_e2e_smoke.py`.
 
-The script intentionally keeps signing, provisioning, and notarization inputs in environment variables or keychain profiles. It must not require secrets in repository files.
+The script intentionally keeps signing, provisioning, notarization, and local smoke inputs in environment variables or keychain profiles. It must not require secrets in repository files.
 
 For contributors without Developer ID/notary credentials, use a development build:
 

--- a/docs/dam-core.md
+++ b/docs/dam-core.md
@@ -84,8 +84,8 @@ Known references become replacements with the stored value. Missing references a
 
 ## Log Value Rules
 
-- Detection, policy-decision, and redaction events may carry the canonical detected value so Activity can show what was detected without reading Wallet.
-- Activity values are local log facts only: they do not create Wallet rows, imply consent, or affect provider pass-through decisions.
+- Detection, policy-decision, and redaction events do not carry raw or canonical sensitive values in `value`; Activity must rely on kind, action, reference, counts, and non-sensitive messages unless it is reading an intentional Wallet/vault reveal surface.
+- Activity values are local log facts only when explicitly supplied by a caller for non-sensitive data; they do not create Wallet rows, imply consent, or affect provider pass-through decisions.
 - References may be logged after successful vault writes.
 - Backend error text must not echo sensitive values.
 

--- a/docs/dam-e2e.md
+++ b/docs/dam-e2e.md
@@ -2,7 +2,7 @@
 
 `dam-e2e` is the process-level end-to-end test package.
 
-It tests multiple DAM binaries and modules together using temp SQLite databases, synthetic data, fake upstreams, and no real provider calls.
+It tests multiple DAM binaries and modules together using temp SQLite databases, synthetic data, fake upstreams, and no real provider calls. The repo also includes a local llama.cpp smoke script for PR verification when a loopback OpenAI-compatible endpoint is available.
 
 ## Scope
 
@@ -45,6 +45,14 @@ cargo clippy --workspace -- -D warnings
 cargo test --workspace
 ```
 
+Local API-through-DAM smoke test for PR evidence:
+
+```bash
+python3 scripts/rpblc_dam_local_llm_e2e_smoke.py --upstream http://127.0.0.1:8080
+```
+
+The script builds `dam-proxy`, starts it on loopback with temporary vault/log SQLite files, sends synthetic email/SSN values through DAM to the local OpenAI-compatible upstream, verifies exact echo resolution on the trusted client side, verifies a token-transformation prompt cannot reconstruct the raw values, reports whether the local activity log database contains the synthetic values, and removes the temp directory unless `--keep-temp` is passed. Exit code `2` means the local upstream or binary prerequisite is blocked rather than a DAM privacy assertion failure.
+
 ## Rules
 
 - Use synthetic data only.
@@ -52,3 +60,4 @@ cargo test --workspace
 - Do not call OpenAI, Anthropic, OpenRouter, or other real providers.
 - Prefer fake upstreams and local processes.
 - Assert that persisted logs do not contain raw sensitive values.
+- For DAM PR readiness, run the local smoke script against a loopback OpenAI-compatible endpoint when available and include the command, upstream, proxy address, expected/actual results, and cleanup status in the PR/report.

--- a/docs/dam-e2e.md
+++ b/docs/dam-e2e.md
@@ -51,7 +51,7 @@ Local API-through-DAM smoke test for PR evidence:
 python3 scripts/rpblc_dam_local_llm_e2e_smoke.py --upstream http://127.0.0.1:8080
 ```
 
-The script builds `dam-proxy`, starts it on loopback with temporary vault/log SQLite files, sends synthetic email/SSN values through DAM to the local OpenAI-compatible upstream, verifies exact echo resolution on the trusted client side, verifies a token-transformation prompt cannot reconstruct the raw values, reports whether the local activity log database contains the synthetic values, and removes the temp directory unless `--keep-temp` is passed. Exit code `2` means the local upstream or binary prerequisite is blocked rather than a DAM privacy assertion failure.
+The script builds `dam-proxy`, starts it on loopback with temporary vault/log SQLite files, sends synthetic email/SSN values through DAM to the local OpenAI-compatible upstream, verifies exact echo resolution on the trusted client side, verifies a token-transformation prompt cannot reconstruct the raw values, fails if the local activity log database contains the synthetic values, and removes the temp directory unless `--keep-temp` is passed. Exit code `2` means the local upstream or binary prerequisite is blocked rather than a DAM privacy assertion failure.
 
 ## Rules
 

--- a/scripts/dam-build.sh
+++ b/scripts/dam-build.sh
@@ -12,6 +12,11 @@ RESTART_AFTER_INSTALL="${DAM_RESTART_AFTER_INSTALL:-1}"
 AGENT_STATUS_STRICT="${DAM_AGENT_STATUS_STRICT:-0}"
 AGENT_NETWORK_MODE="${DAM_AGENT_NETWORK_MODE:-tun}"
 AGENT_TRUST_MODE="${DAM_AGENT_TRUST_MODE:-local_ca}"
+AGENT_E2E_UPSTREAM="${DAM_AGENT_E2E_UPSTREAM:-http://127.0.0.1:8080}"
+AGENT_E2E_LISTEN="${DAM_AGENT_E2E_LISTEN:-127.0.0.1:7831}"
+AGENT_E2E_STARTUP_TIMEOUT="${DAM_AGENT_E2E_STARTUP_TIMEOUT:-30}"
+AGENT_E2E_HTTP_TIMEOUT="${DAM_AGENT_E2E_HTTP_TIMEOUT:-60}"
+AGENT_E2E_SMOKE_SCRIPT="${DAM_AGENT_E2E_SMOKE_SCRIPT:-$ROOT/scripts/rpblc_dam_local_llm_e2e_smoke.py}"
 MACOS_NE_BUNDLE_ID="${DAM_MACOS_NE_BUNDLE_ID:-com.rpblc.dam.network-extension}"
 
 usage() {
@@ -27,6 +32,8 @@ Commands:
   release-macos Run checks, build signed DAM.app, notarize, staple, and zip it
   deploy-local  Build signed DAM.app and copy it to /Applications or --install-dir
   agent-check   Run the standard verification suite plus repo whitespace checks
+  agent-protection-smoke
+                Run local API-through-DAM protection smoke against local upstream
   agent-install Build, notarize when enabled, install, verify, restart, and status DAM
   agent-status  Print installed app, process, package, doctor, and setup status
 
@@ -59,6 +66,14 @@ Environment:
   DAM_AGENT_STATUS_STRICT   Set to 1 to make agent-status fail on probe errors
   DAM_AGENT_NETWORK_MODE    Setup mode for agent-status, currently tun
   DAM_AGENT_TRUST_MODE      Trust mode for agent-status, currently local_ca
+  DAM_AGENT_E2E_UPSTREAM    Local OpenAI-compatible smoke upstream, currently $AGENT_E2E_UPSTREAM
+  DAM_AGENT_E2E_LISTEN      Loopback listen address for smoke proxy, currently $AGENT_E2E_LISTEN
+  DAM_AGENT_E2E_STARTUP_TIMEOUT
+                           Smoke proxy startup timeout, currently $AGENT_E2E_STARTUP_TIMEOUT
+  DAM_AGENT_E2E_HTTP_TIMEOUT
+                           Smoke request timeout, currently $AGENT_E2E_HTTP_TIMEOUT
+  DAM_AGENT_E2E_SMOKE_SCRIPT
+                           Smoke verifier script, currently $AGENT_E2E_SMOKE_SCRIPT
 EOF
 }
 
@@ -238,6 +253,18 @@ cmd_agent_check() {
   else
     printf 'Skipped git diff --check because %s is not a git checkout.\n' "$ROOT"
   fi
+}
+
+cmd_agent_protection_smoke() {
+  if [[ ! -f "$AGENT_E2E_SMOKE_SCRIPT" ]]; then
+    echo "missing local protection smoke script: $AGENT_E2E_SMOKE_SCRIPT" >&2
+    exit 1
+  fi
+  run python3 "$AGENT_E2E_SMOKE_SCRIPT" \
+    --upstream "$AGENT_E2E_UPSTREAM" \
+    --listen "$AGENT_E2E_LISTEN" \
+    --startup-timeout "$AGENT_E2E_STARTUP_TIMEOUT" \
+    --http-timeout "$AGENT_E2E_HTTP_TIMEOUT"
 }
 
 cmd_dev() {
@@ -493,6 +520,7 @@ case "$COMMAND" in
   release-macos) cmd_release_macos ;;
   deploy-local) cmd_deploy_local ;;
   agent-check) cmd_agent_check ;;
+  agent-protection-smoke) cmd_agent_protection_smoke ;;
   agent-install) cmd_agent_install ;;
   agent-status) cmd_agent_status ;;
   *)

--- a/scripts/rpblc_dam_local_llm_e2e_smoke.py
+++ b/scripts/rpblc_dam_local_llm_e2e_smoke.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Local llama.cpp-through-DAM smoke test using synthetic values only.
+
+This script is intentionally stdlib-only so scheduled agents can run it without
+installing Python packages. It starts dam-proxy on loopback with temporary vault
+and log SQLite files, sends OpenAI-compatible chat requests through DAM to a
+local upstream, and checks that the trusted client sees resolved synthetic values
+while a token-transformation prompt cannot reconstruct those raw values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+SYNTHETIC_EMAIL = "alex.sandbox@example.test"
+SYNTHETIC_SSN = "123-45-6789"
+DEFAULT_UPSTREAM = "http://127.0.0.1:8080"
+DEFAULT_LISTEN = "127.0.0.1:7831"
+
+
+class SmokeBlocked(RuntimeError):
+    """Concrete environment blocker, not a DAM verification failure."""
+
+
+def proxy_command(
+    *,
+    binary: Path,
+    listen: str,
+    upstream: str,
+    vault_db: Path,
+    log_db: Path,
+) -> list[str]:
+    return [
+        str(binary),
+        "--listen",
+        listen,
+        "--upstream",
+        upstream,
+        "--provider",
+        "openai-compatible",
+        "--resolve-inbound",
+        "--no-api-key-env",
+        "--db",
+        str(vault_db),
+        "--log",
+        str(log_db),
+    ]
+
+
+def chat_request(prompt: str, *, max_tokens: int = 96) -> dict[str, Any]:
+    return {
+        "model": "local",
+        "temperature": 0,
+        "max_tokens": max_tokens,
+        "stream": False,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Follow the user instruction exactly. Do not explain.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+    }
+
+
+def exact_echo_prompt() -> str:
+    return (
+        "Reply with exactly this protected text and nothing else: "
+        f"email={SYNTHETIC_EMAIL}; ssn={SYNTHETIC_SSN}"
+    )
+
+
+def transform_token_prompt() -> str:
+    return (
+        "Take the exact protected text below, output every character separated "
+        "by a single space, and output nothing else: "
+        f"email={SYNTHETIC_EMAIL}; ssn={SYNTHETIC_SSN}"
+    )
+
+
+def response_text(data: dict[str, Any]) -> str:
+    try:
+        choice = data["choices"][0]
+    except (KeyError, IndexError, TypeError) as error:
+        raise AssertionError(f"OpenAI-compatible response has no choices: {data!r}") from error
+    if "message" in choice:
+        return str(choice.get("message", {}).get("content", ""))
+    return str(choice.get("text", ""))
+
+
+def assert_exact_echo_resolved(text: str) -> None:
+    for value in (SYNTHETIC_EMAIL, SYNTHETIC_SSN):
+        if value not in text:
+            raise AssertionError(f"trusted client response did not resolve {value!r}: {text!r}")
+    if "[email:" in text or "[ssn:" in text:
+        raise AssertionError(f"trusted client response still contains DAM references: {text!r}")
+
+
+def assert_transformed_token_only(text: str) -> None:
+    compact_text = text.replace(" ", "")
+    leaks = [value for value in (SYNTHETIC_EMAIL, SYNTHETIC_SSN) if value in compact_text]
+    if leaks:
+        raise AssertionError(f"transformed-token response leaked raw synthetic values {leaks}: {text!r}")
+    if "[ " not in text and "[" not in compact_text:
+        raise AssertionError(f"model did not appear to transform a DAM token: {text!r}")
+
+
+def post_json(url: str, payload: dict[str, Any], *, timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec: local smoke URL
+        return json.loads(response.read().decode("utf-8"))
+
+
+def get_json(url: str, *, timeout: float) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=timeout) as response:  # nosec: local smoke URL
+        return json.loads(response.read().decode("utf-8"))
+
+
+def upstream_available(upstream: str, *, timeout: float) -> bool:
+    try:
+        get_json(f"{upstream.rstrip('/')}/v1/models", timeout=timeout)
+        return True
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return False
+
+
+def wait_for_proxy(base_url: str, *, timeout: float) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    last_error: BaseException | None = None
+    while time.time() < deadline:
+        try:
+            return get_json(f"{base_url}/health", timeout=1)
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+            last_error = error
+            time.sleep(0.1)
+    raise SmokeBlocked(f"dam-proxy did not become healthy within {timeout}s: {last_error}")
+
+
+def count_log_rows(log_db: Path) -> int:
+    if not log_db.exists():
+        return 0
+    with sqlite3.connect(log_db) as connection:
+        try:
+            return int(connection.execute("select count(*) from log_events").fetchone()[0])
+        except sqlite3.DatabaseError:
+            return 0
+
+
+def raw_values_in_file(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    data = path.read_bytes()
+    return [value for value in (SYNTHETIC_EMAIL, SYNTHETIC_SSN) if value.encode() in data]
+
+
+def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
+    upstream = args.upstream.rstrip("/")
+    if not upstream_available(upstream, timeout=args.http_timeout):
+        raise SmokeBlocked(
+            f"local OpenAI-compatible upstream is unavailable at {upstream}; "
+            "start llama.cpp on 127.0.0.1:8080 or pass --upstream"
+        )
+
+    binary = Path(args.binary)
+    if args.build:
+        subprocess.run(["cargo", "build", "-p", "dam-proxy"], check=True)
+    if not binary.exists():
+        raise SmokeBlocked(f"dam-proxy binary not found: {binary}; rerun with --build")
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="dam-local-llm-smoke-"))
+    vault_db = temp_dir / "vault.sqlite"
+    log_db = temp_dir / "activity.sqlite"
+    listen = args.listen
+    base_url = f"http://{listen}"
+    command = proxy_command(
+        binary=binary,
+        listen=listen,
+        upstream=upstream,
+        vault_db=vault_db,
+        log_db=log_db,
+    )
+
+    process = subprocess.Popen(
+        command,
+        cwd=Path.cwd(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        health = wait_for_proxy(base_url, timeout=args.startup_timeout)
+        exact_prompt = exact_echo_prompt()
+        exact_text = response_text(
+            post_json(
+                f"{base_url}/v1/chat/completions",
+                chat_request(exact_prompt, max_tokens=96),
+                timeout=args.http_timeout,
+            )
+        )
+        assert_exact_echo_resolved(exact_text)
+
+        transform_prompt = transform_token_prompt()
+        transformed_text = response_text(
+            post_json(
+                f"{base_url}/v1/chat/completions",
+                chat_request(transform_prompt, max_tokens=96),
+                timeout=args.http_timeout,
+            )
+        )
+        assert_transformed_token_only(transformed_text)
+
+        raw_in_log = raw_values_in_file(log_db)
+
+        return {
+            "upstream": upstream,
+            "proxy": base_url,
+            "health": health,
+            "vault_db": str(vault_db),
+            "log_db": str(log_db),
+            "log_rows": count_log_rows(log_db),
+            "raw_synthetic_values_in_local_activity_log": raw_in_log,
+            "exact_echo_response": exact_text,
+            "transformed_token_response": transformed_text,
+            "cleanup": "kept" if args.keep_temp else "removed",
+            "temp_dir": str(temp_dir),
+        }
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+        if not args.keep_temp:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--upstream", default=DEFAULT_UPSTREAM)
+    parser.add_argument("--listen", default=DEFAULT_LISTEN)
+    parser.add_argument("--binary", default="target/debug/dam-proxy")
+    parser.add_argument("--build", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--keep-temp", action="store_true")
+    parser.add_argument("--startup-timeout", type=float, default=10)
+    parser.add_argument("--http-timeout", type=float, default=30)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        result = run_smoke(args)
+    except SmokeBlocked as error:
+        print(json.dumps({"status": "blocked", "reason": str(error)}, indent=2), file=sys.stderr)
+        return 2
+    except Exception as error:  # noqa: BLE001 - script boundary reports concrete failure
+        print(json.dumps({"status": "failed", "reason": str(error)}, indent=2), file=sys.stderr)
+        return 1
+
+    print(json.dumps({"status": "passed", **result}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rpblc_dam_local_llm_e2e_smoke.py
+++ b/scripts/rpblc_dam_local_llm_e2e_smoke.py
@@ -78,16 +78,16 @@ def chat_request(prompt: str, *, max_tokens: int = 96) -> dict[str, Any]:
 
 def exact_echo_prompt() -> str:
     return (
-        "Reply with exactly this protected text and nothing else: "
-        f"email={SYNTHETIC_EMAIL}; ssn={SYNTHETIC_SSN}"
+        "For a local synthetic test, reply with exactly this text and nothing else: "
+        f"alpha={SYNTHETIC_EMAIL}; beta={SYNTHETIC_SSN}"
     )
 
 
 def transform_token_prompt() -> str:
     return (
-        "Take the exact protected text below, output every character separated "
-        "by a single space, and output nothing else: "
-        f"email={SYNTHETIC_EMAIL}; ssn={SYNTHETIC_SSN}"
+        "For a local synthetic test, take the exact text below, output every "
+        "character separated by a single space, and output nothing else: "
+        f"alpha={SYNTHETIC_EMAIL}; beta={SYNTHETIC_SSN}"
     )
 
 
@@ -172,6 +172,15 @@ def raw_values_in_file(path: Path) -> list[str]:
     return [value for value in (SYNTHETIC_EMAIL, SYNTHETIC_SSN) if value.encode() in data]
 
 
+def assert_no_raw_values_in_activity_log(log_db: Path) -> None:
+    leaked_values = raw_values_in_file(log_db)
+    if leaked_values:
+        raise AssertionError(
+            "activity log leaked raw synthetic values outside the vault: "
+            f"{', '.join(leaked_values)}"
+        )
+
+
 def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
     upstream = args.upstream.rstrip("/")
     if not upstream_available(upstream, timeout=args.http_timeout):
@@ -229,6 +238,7 @@ def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
         )
         assert_transformed_token_only(transformed_text)
 
+        assert_no_raw_values_in_activity_log(log_db)
         raw_in_log = raw_values_in_file(log_db)
 
         return {

--- a/scripts/rpblc_dam_local_llm_e2e_smoke.py
+++ b/scripts/rpblc_dam_local_llm_e2e_smoke.py
@@ -110,11 +110,12 @@ def assert_exact_echo_resolved(text: str) -> None:
 
 
 def assert_transformed_token_only(text: str) -> None:
-    compact_text = text.replace(" ", "")
+    compact_text = "".join(text.split())
     leaks = [value for value in (SYNTHETIC_EMAIL, SYNTHETIC_SSN) if value in compact_text]
     if leaks:
         raise AssertionError(f"transformed-token response leaked raw synthetic values {leaks}: {text!r}")
-    if "[ " not in text and "[" not in compact_text:
+    compact_lower = compact_text.lower()
+    if "[email:" not in compact_lower and "[ssn:" not in compact_lower:
         raise AssertionError(f"model did not appear to transform a DAM token: {text!r}")
 
 

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -1,0 +1,81 @@
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = ROOT / "scripts" / "dam-build.sh"
+
+
+class DamBuildScriptTests(unittest.TestCase):
+    def test_help_documents_agent_protection_smoke_command(self):
+        result = subprocess.run(
+            [str(BUILD_SCRIPT), "--help"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+        self.assertIn("agent-protection-smoke", result.stdout)
+        self.assertIn("DAM_AGENT_E2E_UPSTREAM", result.stdout)
+
+    def test_agent_protection_smoke_invokes_local_smoke_script_with_safe_defaults(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "argv.txt"
+            stub_path = Path(temp_dir) / "smoke_stub.py"
+            stub_path.write_text(
+                textwrap.dedent(
+                    f"""
+                    import pathlib
+                    import sys
+                    pathlib.Path({str(output_path)!r}).write_text("\\n".join(sys.argv[1:]), encoding="utf-8")
+                    raise SystemExit(0)
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DAM_AGENT_E2E_SMOKE_SCRIPT": str(stub_path),
+                    "DAM_AGENT_E2E_UPSTREAM": "http://127.0.0.1:18080",
+                    "DAM_AGENT_E2E_LISTEN": "127.0.0.1:17831",
+                    "DAM_AGENT_E2E_STARTUP_TIMEOUT": "7",
+                    "DAM_AGENT_E2E_HTTP_TIMEOUT": "11",
+                }
+            )
+            subprocess.run(
+                [str(BUILD_SCRIPT), "agent-protection-smoke"],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+
+            argv = output_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                argv,
+                [
+                    "--upstream",
+                    "http://127.0.0.1:18080",
+                    "--listen",
+                    "127.0.0.1:17831",
+                    "--startup-timeout",
+                    "7",
+                    "--http-timeout",
+                    "11",
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_llm_e2e_smoke_script.py
+++ b/tests/test_local_llm_e2e_smoke_script.py
@@ -101,6 +101,25 @@ class LocalLlmE2eSmokeScriptTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "raw synthetic values"):
             smoke.assert_transformed_token_only(f"leaked {smoke.SYNTHETIC_EMAIL}")
 
+    def test_transformed_token_assertion_rejects_whitespace_obfuscated_raw_values(self):
+        smoke = load_module()
+
+        obfuscated_email = " \n ".join(smoke.SYNTHETIC_EMAIL)
+        obfuscated_ssn = "\t".join(smoke.SYNTHETIC_SSN)
+
+        with self.assertRaisesRegex(AssertionError, "raw synthetic values"):
+            smoke.assert_transformed_token_only(obfuscated_email)
+        with self.assertRaisesRegex(AssertionError, "raw synthetic values"):
+            smoke.assert_transformed_token_only(obfuscated_ssn)
+
+    def test_transformed_token_assertion_requires_dam_reference_kind(self):
+        smoke = load_module()
+
+        smoke.assert_transformed_token_only("model saw [ e m a i l : a b c 1 2 3 ]")
+
+        with self.assertRaisesRegex(AssertionError, "DAM token"):
+            smoke.assert_transformed_token_only("model saw [ not-a-dam-reference ]")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_local_llm_e2e_smoke_script.py
+++ b/tests/test_local_llm_e2e_smoke_script.py
@@ -87,6 +87,16 @@ class LocalLlmE2eSmokeScriptTests(unittest.TestCase):
 
             self.assertEqual(smoke.count_log_rows(db_path), 3)
 
+    def test_activity_log_assertion_fails_closed_on_raw_synthetic_values(self):
+        smoke = load_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "activity.sqlite"
+            db_path.write_text(f"raw {smoke.SYNTHETIC_EMAIL}", encoding="utf-8")
+
+            with self.assertRaisesRegex(AssertionError, "activity log leaked raw synthetic values"):
+                smoke.assert_no_raw_values_in_activity_log(db_path)
+
     def test_assertions_distinguish_resolved_and_transformed_token_outputs(self):
         smoke = load_module()
 

--- a/tests/test_local_llm_e2e_smoke_script.py
+++ b/tests/test_local_llm_e2e_smoke_script.py
@@ -1,0 +1,106 @@
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "rpblc_dam_local_llm_e2e_smoke.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("rpblc_dam_local_llm_e2e_smoke", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class LocalLlmE2eSmokeScriptTests(unittest.TestCase):
+    def test_proxy_command_uses_loopback_temp_stores_and_no_api_key_env(self):
+        smoke = load_module()
+
+        command = smoke.proxy_command(
+            binary=Path("target/debug/dam-proxy"),
+            listen="127.0.0.1:7831",
+            upstream="http://127.0.0.1:8080",
+            vault_db=Path("/tmp/dam-smoke/vault.sqlite"),
+            log_db=Path("/tmp/dam-smoke/log.sqlite"),
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "target/debug/dam-proxy",
+                "--listen",
+                "127.0.0.1:7831",
+                "--upstream",
+                "http://127.0.0.1:8080",
+                "--provider",
+                "openai-compatible",
+                "--resolve-inbound",
+                "--no-api-key-env",
+                "--db",
+                "/tmp/dam-smoke/vault.sqlite",
+                "--log",
+                "/tmp/dam-smoke/log.sqlite",
+            ],
+        )
+
+    def test_prompts_are_deterministic_and_contain_synthetic_values_only(self):
+        smoke = load_module()
+
+        exact_prompt = smoke.exact_echo_prompt()
+        transform_prompt = smoke.transform_token_prompt()
+        request = smoke.chat_request(exact_prompt, max_tokens=48)
+
+        self.assertEqual(request["model"], "local")
+        self.assertEqual(request["temperature"], 0)
+        self.assertEqual(request["max_tokens"], 48)
+        self.assertEqual(request["messages"][-1]["content"], exact_prompt)
+        serialized = smoke.json.dumps([exact_prompt, transform_prompt, request])
+        self.assertIn(smoke.SYNTHETIC_EMAIL, serialized)
+        self.assertIn(smoke.SYNTHETIC_SSN, serialized)
+        self.assertIn("every character separated", transform_prompt)
+        self.assertNotIn("api.openai.com", serialized)
+
+    def test_response_text_extracts_openai_compatible_content(self):
+        smoke = load_module()
+
+        data = {
+            "choices": [
+                {"message": {"content": "resolved text"}},
+                {"message": {"content": "ignored"}},
+            ]
+        }
+
+        self.assertEqual(smoke.response_text(data), "resolved text")
+
+    def test_count_log_rows_reads_dam_log_events_table(self):
+        smoke = load_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "activity.sqlite"
+            with sqlite3.connect(db_path) as connection:
+                connection.execute("create table log_events (id integer primary key)")
+                connection.executemany("insert into log_events default values", [(), (), ()])
+
+            self.assertEqual(smoke.count_log_rows(db_path), 3)
+
+    def test_assertions_distinguish_resolved_and_transformed_token_outputs(self):
+        smoke = load_module()
+
+        smoke.assert_exact_echo_resolved(
+            f"client sees {smoke.SYNTHETIC_EMAIL} and {smoke.SYNTHETIC_SSN}"
+        )
+        smoke.assert_transformed_token_only("model saw [ email:abc123] and [ secret:def456]")
+
+        with self.assertRaisesRegex(AssertionError, smoke.SYNTHETIC_EMAIL):
+            smoke.assert_exact_echo_resolved("client sees only [email:abc123]")
+
+        with self.assertRaisesRegex(AssertionError, "raw synthetic values"):
+            smoke.assert_transformed_token_only(f"leaked {smoke.SYNTHETIC_EMAIL}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What I did
- Added `scripts/rpblc_dam_local_llm_e2e_smoke.py` for local llama.cpp/OpenAI-compatible API-through-DAM PR verification.
- Added `scripts/dam-build.sh agent-protection-smoke` as the documented agent wrapper for that local protection E2E smoke path, with env overrides for upstream/listen/timeouts/script path.
- Added stdlib unittest coverage for the smoke script helpers and the new build-script wrapper/dispatch.
- Hardened the token-transformation assertion so whitespace-obfuscated raw synthetic values fail, transformed output must contain a DAM email/SSN reference kind, and activity-log raw synthetic leaks fail closed.
- Fixed verification blockers found in follow-up runs: debug `dam connect` now waits long enough for daemon startup state to be written after hashing large debug binaries, and macOS Network Extension helper-driven unit tests can run under `cfg(test)` on Linux while non-test non-macOS execution remains unsupported.
- Installed the missing local Rust verification components on this runner and fixed newly surfaced formatting/clippy/test issues so the standard `agent-check` is green on this Linux runner.

Why I did it
- DAM needs repeatable evidence that traffic routes through `dam-proxy`, synthetic sensitive values are tokenized before the local model sees them, trusted-side resolution works, and token-transformation prompts cannot reconstruct raw values.
- The smoke verifier should fail closed on adversarial whitespace transformations, non-DAM bracketed output, and raw synthetic values persisted outside the vault.
- The PR verification gate should be reliable on Linux without weakening macOS Network Extension production safety.
- Agents should have one stable command for the mandatory local protection smoke instead of hand-replaying the Python script flags.

How I did it
- The script starts `dam-proxy` on `127.0.0.1` with temporary vault/log SQLite files, points it at `http://127.0.0.1:8080`, sends synthetic email/SSN prompts to `/v1/chat/completions`, verifies exact echo resolution, verifies a spaced-character token transform does not reveal raw values, fails if local activity logs contain raw synthetic values, terminates the proxy process, and removes the temp directory.
- `agent-protection-smoke` delegates to the smoke script with safe loopback defaults: `DAM_AGENT_E2E_UPSTREAM`, `DAM_AGENT_E2E_LISTEN`, `DAM_AGENT_E2E_STARTUP_TIMEOUT`, `DAM_AGENT_E2E_HTTP_TIMEOUT`, and `DAM_AGENT_E2E_SMOKE_SCRIPT` can override local-only inputs without storing secrets.
- Follow-up hardening compacts all whitespace before raw-leak checks, requires `[email:` or `[ssn:` after compaction, makes activity-log raw-value leakage fail closed, removes raw/canonical sensitive values from detection/policy/redaction log `value` fields, preserves full JSON-string traversal side effects while satisfying clippy, and keeps Linux verification from treating macOS helper-backed unit tests as unsupported platform failures.

Branch: `test/local-llm-e2e-smoke-script`
Companion architecture PR: RPBLC-hq/Architecture#5

Tests/results
- RED: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test_local_llm_e2e_smoke_script.py -v` initially failed for the new whitespace-obfuscated raw-value and non-DAM-reference checks.
- RED: `cargo test -p dam-e2e dam_connect_status_disconnect_tracks_profile_target -- --nocapture` failed with `DAM daemon did not become ready`; manual reproduction showed debug daemon state was written after ~11.5s because the large debug binary SHA-256 is computed before state write, longer than the old 8s connect wait.
- RED: `scripts/dam-build.sh agent-check` then reached `dam-net-macos` Linux unit-test failures because helper-backed macOS Network Extension tests were gated by runtime platform instead of test-mode helper simulation.
- RED: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test_dam_build_script.py -v` failed because `agent-protection-smoke` was not in help/dispatch yet.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test_local_llm_e2e_smoke_script.py -v`: passed, 8 tests.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test_dam_build_script.py tests/test_local_llm_e2e_smoke_script.py -v`: passed, 10 tests.
- `bash -n scripts/dam-build.sh`: passed.
- `scripts/dam-build.sh agent-protection-smoke`: passed. Upstream `http://127.0.0.1:8080`; proxy `http://127.0.0.1:7831`; health state `protected`; exact echo response resolved synthetic email/SSN on trusted client side; transformed-token response contained spaced DAM email/SSN references, not raw values; `raw_synthetic_values_in_local_activity_log` was `[]`; temp dir removed.
- `python3 scripts/rpblc_dam_local_llm_e2e_smoke.py --upstream http://127.0.0.1:8080 --startup-timeout 30 --http-timeout 60`: passed with the same local upstream/proxy/resolution/raw-log-leak evidence.
- `cargo test -p dam-e2e web_api_reads_vault_and_activity_populated_by_filter --test local_flow -- --nocapture`: passed, 1 targeted test.
- `cargo test -p dam-e2e --test local_flow -- --nocapture`: passed, 11 tests.
- `cargo test -p dam-net-macos --lib`: passed, 36 tests.
- `cargo test -p dam --bin dam local_ca_install_and_remove_preview_require_approval`: passed.
- `scripts/dam-build.sh agent-check`: passed end-to-end on this Linux runner: npm ci/build/test/pack, `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, and `git diff --check`.
- Static added-line scan for hardcoded secret/shell injection/eval/exec/pickle/SQL formatting patterns: none.

Doc/design sync
- DAM docs updated in `docs/dam-e2e.md`, `docs/dam-core.md`, `docs/build-release.md`, and `docs/README.md`.
- Architecture contract updated in companion PR RPBLC-hq/Architecture#5, including `dam/build-release.md` and `dam/todo.md` for the new agent protection-smoke wrapper.
- No `RPBLC.Design` change was needed; this is CLI/test automation and privacy-log behavior, not a visual/UI contract change.

Risks/failsafe notes
- No system network configuration or interception settings were changed.
- Smoke test uses loopback only, synthetic values only, temporary SQLite stores, explicit proxy process termination, and temp directory cleanup.
- Uses local upstream only; no paid provider/API traffic.
- macOS Network Extension execution remains unsupported in non-test non-macOS builds; the Linux change only lets helper-backed unit tests exercise the same code paths under `cfg(test)`.

Next step
- Review/merge the companion Architecture PR and this DAM PR together; after merge, consider adding `agent-repair-smoke`/uninstall coverage so the release-smoke TODO can keep shrinking toward one full release candidate command.
