### PR TITLE
test: expose DAM smoke debug options

### DIFF
--- a/docs/build-release.md
+++ b/docs/build-release.md
@@ -34,7 +34,7 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 
 `agent-check` is the default verification command for local agents and maintainers. It runs `check` and adds `git diff --check` when the source tree is a git checkout.
 
-`agent-protection-smoke` runs the local API-through-DAM protection smoke test against a loopback OpenAI-compatible upstream. By default it uses local llama.cpp at `http://127.0.0.1:8080`, starts `dam-proxy` on `127.0.0.1:7831`, uses temporary vault/activity SQLite stores, sends synthetic email/SSN values only, verifies trusted-side resolution, verifies the model can transform only DAM references by inserting whitespace after reference opening brackets, checks the activity log for raw synthetic leaks, then terminates the proxy and removes the temporary stores. If `dam-proxy` exits before becoming healthy, the command fails with the captured exit code and stdout/stderr tail so port/config problems are actionable. It does not change system network settings or call paid providers.
+`agent-protection-smoke` runs the local API-through-DAM protection smoke test against a loopback OpenAI-compatible upstream. By default it uses local llama.cpp at `http://127.0.0.1:8080`, builds and runs `target/debug/dam-proxy` on `127.0.0.1:7831`, uses temporary vault/activity SQLite stores, sends synthetic email/SSN values only, verifies trusted-side resolution, verifies the model can transform only DAM references by inserting whitespace after reference opening brackets, checks the activity log for raw synthetic leaks, then terminates the proxy and removes the temporary stores. If `dam-proxy` exits before becoming healthy, the command fails with the captured exit code and stdout/stderr tail so port/config problems are actionable. It does not change system network settings or call paid providers. Set `DAM_AGENT_E2E_BINARY` to test a specific proxy binary, `DAM_AGENT_E2E_BUILD=0` to reuse an existing binary, or `DAM_AGENT_E2E_KEEP_TEMP=1` to retain temporary smoke-test stores for debugging.
 
 `agent-install` is the idempotent local release-path install command for macOS. It optionally runs `agent-check`, builds the app, notarizes Developer ID builds unless notarization is disabled, stops the installed tray/web processes before replacing the app bundle, verifies the installed app, refreshes app-owned System Extension activation, reconfigures the Network Extension manager for `tun` installs, restarts the daemon with the persisted DAM configuration, opens the tray app, and prints `agent-status`.
 
@@ -59,6 +59,9 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 - `DAM_AGENT_E2E_STARTUP_TIMEOUT`: smoke proxy startup timeout in seconds, default `30`.
 - `DAM_AGENT_E2E_HTTP_TIMEOUT`: smoke request timeout in seconds, default `60`.
 - `DAM_AGENT_E2E_SMOKE_SCRIPT`: verifier script path, default `scripts/rpblc_dam_local_llm_e2e_smoke.py`.
+- `DAM_AGENT_E2E_BINARY`: `dam-proxy` binary path for the smoke test, default `target/debug/dam-proxy`.
+- `DAM_AGENT_E2E_BUILD`: set to `0` to skip the default smoke-test `cargo build -p dam-proxy` step.
+- `DAM_AGENT_E2E_KEEP_TEMP`: set to `1` to retain the smoke-test temporary vault/log directory for debugging.
 
 The script intentionally keeps signing, provisioning, notarization, and local smoke inputs in environment variables or keychain profiles. It must not require secrets in repository files.
 

--- a/scripts/dam-build.sh
+++ b/scripts/dam-build.sh
@@ -17,6 +17,9 @@ AGENT_E2E_LISTEN="${DAM_AGENT_E2E_LISTEN:-127.0.0.1:7831}"
 AGENT_E2E_STARTUP_TIMEOUT="${DAM_AGENT_E2E_STARTUP_TIMEOUT:-30}"
 AGENT_E2E_HTTP_TIMEOUT="${DAM_AGENT_E2E_HTTP_TIMEOUT:-60}"
 AGENT_E2E_SMOKE_SCRIPT="${DAM_AGENT_E2E_SMOKE_SCRIPT:-$ROOT/scripts/rpblc_dam_local_llm_e2e_smoke.py}"
+AGENT_E2E_BINARY="${DAM_AGENT_E2E_BINARY:-$ROOT/target/debug/dam-proxy}"
+AGENT_E2E_BUILD="${DAM_AGENT_E2E_BUILD:-1}"
+AGENT_E2E_KEEP_TEMP="${DAM_AGENT_E2E_KEEP_TEMP:-0}"
 MACOS_NE_BUNDLE_ID="${DAM_MACOS_NE_BUNDLE_ID:-com.rpblc.dam.network-extension}"
 
 usage() {
@@ -74,6 +77,9 @@ Environment:
                            Smoke request timeout, currently $AGENT_E2E_HTTP_TIMEOUT
   DAM_AGENT_E2E_SMOKE_SCRIPT
                            Smoke verifier script, currently $AGENT_E2E_SMOKE_SCRIPT
+  DAM_AGENT_E2E_BINARY     dam-proxy binary path for smoke, currently $AGENT_E2E_BINARY
+  DAM_AGENT_E2E_BUILD      Set to 0 to reuse the binary without cargo build, currently $AGENT_E2E_BUILD
+  DAM_AGENT_E2E_KEEP_TEMP  Set to 1 to keep smoke temp vault/log files, currently $AGENT_E2E_KEEP_TEMP
 EOF
 }
 
@@ -260,11 +266,21 @@ cmd_agent_protection_smoke() {
     echo "missing local protection smoke script: $AGENT_E2E_SMOKE_SCRIPT" >&2
     exit 1
   fi
-  run python3 "$AGENT_E2E_SMOKE_SCRIPT" \
-    --upstream "$AGENT_E2E_UPSTREAM" \
-    --listen "$AGENT_E2E_LISTEN" \
-    --startup-timeout "$AGENT_E2E_STARTUP_TIMEOUT" \
+  local smoke_args=(
+    "$AGENT_E2E_SMOKE_SCRIPT"
+    --upstream "$AGENT_E2E_UPSTREAM"
+    --listen "$AGENT_E2E_LISTEN"
+    --startup-timeout "$AGENT_E2E_STARTUP_TIMEOUT"
     --http-timeout "$AGENT_E2E_HTTP_TIMEOUT"
+    --binary "$AGENT_E2E_BINARY"
+  )
+  if [[ "$AGENT_E2E_BUILD" == "0" ]]; then
+    smoke_args+=(--no-build)
+  fi
+  if [[ "$AGENT_E2E_KEEP_TEMP" == "1" ]]; then
+    smoke_args+=(--keep-temp)
+  fi
+  run python3 "${smoke_args[@]}"
 }
 
 cmd_dev() {

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -24,6 +24,9 @@ class DamBuildScriptTests(unittest.TestCase):
 
         self.assertIn("agent-protection-smoke", result.stdout)
         self.assertIn("DAM_AGENT_E2E_UPSTREAM", result.stdout)
+        self.assertIn("DAM_AGENT_E2E_BINARY", result.stdout)
+        self.assertIn("DAM_AGENT_E2E_BUILD", result.stdout)
+        self.assertIn("DAM_AGENT_E2E_KEEP_TEMP", result.stdout)
 
     def test_agent_protection_smoke_invokes_local_smoke_script_with_safe_defaults(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -73,8 +76,52 @@ class DamBuildScriptTests(unittest.TestCase):
                     "7",
                     "--http-timeout",
                     "11",
+                    "--binary",
+                    str(ROOT / "target" / "debug" / "dam-proxy"),
                 ],
             )
+
+    def test_agent_protection_smoke_passes_debug_options_from_environment(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "argv.txt"
+            stub_path = Path(temp_dir) / "smoke_stub.py"
+            binary_path = Path(temp_dir) / "dam-proxy"
+            stub_path.write_text(
+                textwrap.dedent(
+                    f"""
+                    import pathlib
+                    import sys
+                    pathlib.Path({str(output_path)!r}).write_text("\\n".join(sys.argv[1:]), encoding="utf-8")
+                    raise SystemExit(0)
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DAM_AGENT_E2E_SMOKE_SCRIPT": str(stub_path),
+                    "DAM_AGENT_E2E_BINARY": str(binary_path),
+                    "DAM_AGENT_E2E_BUILD": "0",
+                    "DAM_AGENT_E2E_KEEP_TEMP": "1",
+                }
+            )
+            subprocess.run(
+                [str(BUILD_SCRIPT), "agent-protection-smoke"],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+
+            argv = output_path.read_text(encoding="utf-8").splitlines()
+            self.assertIn("--binary", argv)
+            self.assertIn(str(binary_path), argv)
+            self.assertIn("--no-build", argv)
+            self.assertIn("--keep-temp", argv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
What I did
- Added `agent-protection-smoke` environment controls for smoke-test debugging:
  - `DAM_AGENT_E2E_BINARY` selects the `dam-proxy` binary under test.
  - `DAM_AGENT_E2E_BUILD=0` reuses an existing binary instead of rebuilding.
  - `DAM_AGENT_E2E_KEEP_TEMP=1` keeps temporary vault/log stores for inspection.
- Documented the new controls in `docs/build-release.md`.
- Added wrapper tests for help text, default smoke arguments, and debug option forwarding.

Why I did it
- The local API-through-DAM smoke test is now easier to use for release/debug loops: agents and maintainers can reproduce a proxy failure against a specific binary, skip redundant rebuilds, and inspect temporary stores without editing scripts.

How I did it
- Kept the default safe path unchanged: local loopback upstream/proxy, no system network mutation, synthetic test values only, and automatic build/cleanup by default.
- Made debugging opt-in through environment variables.

Branch/PR
- Branch: `chore/agent-smoke-debug-options`

Tests/results
- `python3 -m unittest tests.test_dam_build_script -v`
- `bash -n scripts/dam-build.sh`
- static added-line security scan: no findings
- `scripts/dam-build.sh agent-check`
- `DAM_AGENT_E2E_BUILD=0 DAM_AGENT_E2E_KEEP_TEMP=1 scripts/dam-build.sh agent-protection-smoke` passed against local loopback OpenAI-compatible upstream; temp files were removed after verification.

Doc/design/TODO sync
- DAM docs updated in `docs/build-release.md`.
- No Architecture repo change needed: this is a local release-smoke ergonomics/debugging control, not a new product contract or network behavior.

Risk/failsafe notes
- No host routing, trust, or interception settings were changed.
- New behavior is opt-in via environment variables; defaults preserve current build-and-cleanup behavior.

Next step
- Review and merge if CI is green.
