### PR TITLE
fix: make strict agent status fail on doctor errors

### DIFF
--- a/scripts/dam-build.sh
+++ b/scripts/dam-build.sh
@@ -222,21 +222,6 @@ status_try() {
   return 0
 }
 
-status_observe() {
-  printf '+'
-  printf ' %q' "$@"
-  printf '\n'
-  if "$@"; then
-    return 0
-  else
-    local status=$?
-    printf 'status probe reported non-ready (%s):' "$status"
-    printf ' %q' "$@"
-    printf '\n'
-  fi
-  return 0
-}
-
 cmd_check() {
   if [[ -f "$ROOT/crates/dam-web/ui/package.json" ]]; then
     run npm ci --prefix "$ROOT/crates/dam-web/ui"
@@ -395,7 +380,7 @@ cmd_agent_status() {
     status_try failures xcrun stapler validate "$app"
     status_try failures spctl -a -vvv -t exec "$app"
   fi
-  status_observe "$dam_bin" doctor --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
+  status_try failures "$dam_bin" doctor --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
   status_try failures "$dam_bin" setup status --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
   status_try failures "$dam_bin" setup next-action --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
   status_try failures "$dam_bin" status --json

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -81,6 +81,60 @@ class DamBuildScriptTests(unittest.TestCase):
                 ],
             )
 
+    def test_agent_status_strict_fails_when_doctor_probe_fails(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            bin_dir = temp_path / "bin"
+            app_dir = temp_path / "DAM.app"
+            dam_bin = app_dir / "Contents" / "MacOS" / "dam"
+            bin_dir.mkdir()
+            dam_bin.parent.mkdir(parents=True)
+
+            for command in ["uname", "pgrep", "codesign", "xcrun", "spctl"]:
+                script = bin_dir / command
+                if command == "uname":
+                    script.write_text("#!/usr/bin/env sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+                elif command == "pgrep":
+                    script.write_text("#!/usr/bin/env sh\nexit 1\n", encoding="utf-8")
+                else:
+                    script.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+                script.chmod(0o755)
+
+            dam_bin.write_text(
+                textwrap.dedent(
+                    """
+                    #!/usr/bin/env sh
+                    if [ "$1" = "doctor" ]; then
+                      exit 7
+                    fi
+                    exit 0
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            dam_bin.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DAM_INSTALL_DIR": str(temp_path),
+                    "DAM_SIGN_MODE": "development",
+                    "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                }
+            )
+            result = subprocess.run(
+                [str(BUILD_SCRIPT), "agent-status", "--strict-status"],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+            self.assertIn("status_probe_failures: 1", result.stdout)
+            self.assertIn("doctor", result.stdout)
+
     def test_agent_protection_smoke_passes_debug_options_from_environment(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "argv.txt"


### PR DESCRIPTION
What I did
- Fixed `scripts/dam-build.sh agent-status --strict-status` so `dam doctor --json` failures count as status probe failures.
- Added a regression test that stubs a macOS installed-app environment and proves strict status exits non-zero when the doctor probe fails.

Why I did it
- `agent-status` is part of the install/release-path operator loop. Strict mode was documented as failing when any probe fails, but doctor was only observed and did not affect `status_probe_failures`, which could let broken installed-app diagnostics appear green.

How I did it
- Reused the existing `status_try` path for the doctor probe.
- Removed the now-unused observe-only helper.
- Verified with the targeted test, full build-script tests, `scripts/dam-build.sh agent-check`, and the loopback API-through-DAM protection smoke test.

Branch/PR
- Branch: `fix/agent-status-strict-doctor`

Tests/results
- `python3 -m unittest tests.test_dam_build_script.DamBuildScriptTests.test_agent_status_strict_fails_when_doctor_probe_fails -v`
- `python3 -m unittest tests.test_dam_build_script -v`
- `bash -n scripts/dam-build.sh && git diff --check`
- `scripts/dam-build.sh agent-check`
- `scripts/dam-build.sh agent-protection-smoke`

Doc/design/TODO sync
- No architecture contract change needed; this makes the implementation match existing `agent-status` strict-mode documentation.

Risk/failsafe notes
- Low risk: local build/release script behavior only. No host network settings were changed. The protection smoke test used loopback-only synthetic PII against local llama.cpp.

Next step
- Review and merge if CI is green.
