### PR TITLE
chore: add installed recovery smoke command

### DIFF
--- a/docs/build-release.md
+++ b/docs/build-release.md
@@ -14,6 +14,7 @@ scripts/dam-build.sh release-macos --mode developer-id
 scripts/dam-build.sh deploy-local --mode development
 scripts/dam-build.sh agent-check
 scripts/dam-build.sh agent-protection-smoke
+scripts/dam-build.sh agent-recovery-smoke --network-mode tun --trust-mode local_ca
 scripts/dam-build.sh agent-install --skip-checks
 scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 ```
@@ -35,6 +36,8 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 `agent-check` is the default verification command for local agents and maintainers. It runs `check` and adds `git diff --check` when the source tree is a git checkout.
 
 `agent-protection-smoke` runs the local API-through-DAM protection smoke test against a loopback OpenAI-compatible upstream. By default it uses local llama.cpp at `http://127.0.0.1:8080`, builds and runs `target/debug/dam-proxy` on `127.0.0.1:7831`, uses temporary vault/activity SQLite stores, sends synthetic email/SSN values only, verifies trusted-side resolution, verifies the model can transform only DAM references by inserting whitespace after reference opening brackets, checks the activity log for raw synthetic leaks, then terminates the proxy and removes the temporary stores. If `dam-proxy` exits before becoming healthy, the command fails with the captured exit code and stdout/stderr tail so port/config problems are actionable. It does not change system network settings or call paid providers. Set `DAM_AGENT_E2E_BINARY` to test a specific proxy binary, `DAM_AGENT_E2E_BUILD=0` to reuse an existing binary, or `DAM_AGENT_E2E_KEEP_TEMP=1` to retain temporary smoke-test stores for debugging.
+
+`agent-recovery-smoke` runs the installed app's read-only recovery probes without changing routing or daemon state: `dam setup rescue --dry-run --json`, `dam setup repair --dry-run --json`, and `dam setup export-diagnostics --json`. It uses the same `--network-mode`, `--trust-mode`, `DAM_AGENT_NETWORK_MODE`, and `DAM_AGENT_TRUST_MODE` inputs as `agent-status` for the setup diagnostics export. Use it after `agent-install` when validating that the installed release artifact can explain and preview recovery actions before any mutating rescue/repair is attempted.
 
 `agent-install` is the idempotent local release-path install command for macOS. It optionally runs `agent-check`, builds the app, notarizes Developer ID builds unless notarization is disabled, stops the installed tray/web processes before replacing the app bundle, verifies the installed app, refreshes app-owned System Extension activation, reconfigures the Network Extension manager for `tun` installs, restarts the daemon with the persisted DAM configuration, opens the tray app, and prints `agent-status`.
 

--- a/scripts/dam-build.sh
+++ b/scripts/dam-build.sh
@@ -37,6 +37,8 @@ Commands:
   agent-check   Run the standard verification suite plus repo whitespace checks
   agent-protection-smoke
                 Run local API-through-DAM protection smoke against local upstream
+  agent-recovery-smoke
+                Run read-only installed rescue/repair/diagnostics recovery probes
   agent-install Build, notarize when enabled, install, verify, restart, and status DAM
   agent-status  Print installed app, process, package, doctor, and setup status
 
@@ -391,6 +393,32 @@ cmd_agent_status() {
   fi
 }
 
+cmd_agent_recovery_smoke() {
+  require_macos
+  local app dam_bin
+  app="$(installed_app_path)"
+  printf 'DAM agent recovery smoke\n'
+  printf 'install_dir: %s\n' "$INSTALL_DIR"
+  printf 'app: %s\n' "$app"
+  printf 'setup_probe_network_mode: %s\n' "$AGENT_NETWORK_MODE"
+  printf 'setup_probe_trust_mode: %s\n' "$AGENT_TRUST_MODE"
+
+  if [[ ! -d "$app" ]]; then
+    echo "installed app not found" >&2
+    exit 1
+  fi
+
+  dam_bin="$app/Contents/MacOS/dam"
+  if [[ ! -x "$dam_bin" ]]; then
+    echo "installed dam binary not found: $dam_bin" >&2
+    exit 1
+  fi
+
+  run "$dam_bin" setup rescue --dry-run --json
+  run "$dam_bin" setup repair --dry-run --json
+  run "$dam_bin" setup export-diagnostics --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
+}
+
 cmd_agent_install() {
   require_macos
   if [[ "${SKIP_CHECKS:-0}" != "1" ]]; then
@@ -522,6 +550,7 @@ case "$COMMAND" in
   deploy-local) cmd_deploy_local ;;
   agent-check) cmd_agent_check ;;
   agent-protection-smoke) cmd_agent_protection_smoke ;;
+  agent-recovery-smoke) cmd_agent_recovery_smoke ;;
   agent-install) cmd_agent_install ;;
   agent-status) cmd_agent_status ;;
   *)

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -23,6 +23,7 @@ class DamBuildScriptTests(unittest.TestCase):
         )
 
         self.assertIn("agent-protection-smoke", result.stdout)
+        self.assertIn("agent-recovery-smoke", result.stdout)
         self.assertIn("DAM_AGENT_E2E_UPSTREAM", result.stdout)
         self.assertIn("DAM_AGENT_E2E_BINARY", result.stdout)
         self.assertIn("DAM_AGENT_E2E_BUILD", result.stdout)
@@ -134,6 +135,64 @@ class DamBuildScriptTests(unittest.TestCase):
             self.assertEqual(1, result.returncode, result.stdout + result.stderr)
             self.assertIn("status_probe_failures: 1", result.stdout)
             self.assertIn("doctor", result.stdout)
+
+    def test_agent_recovery_smoke_runs_read_only_installed_recovery_probes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            bin_dir = temp_path / "bin"
+            app_dir = temp_path / "DAM.app"
+            dam_bin = app_dir / "Contents" / "MacOS" / "dam"
+            calls_path = temp_path / "dam-calls.txt"
+            bin_dir.mkdir()
+            dam_bin.parent.mkdir(parents=True)
+
+            uname = bin_dir / "uname"
+            uname.write_text("#!/usr/bin/env sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+            uname.chmod(0o755)
+            dam_bin.write_text(
+                textwrap.dedent(
+                    f"""
+                    #!/usr/bin/env sh
+                    printf '%s\\n' "$*" >> {str(calls_path)!r}
+                    exit 0
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            dam_bin.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DAM_INSTALL_DIR": str(temp_path),
+                    "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                }
+            )
+            subprocess.run(
+                [
+                    str(BUILD_SCRIPT),
+                    "agent-recovery-smoke",
+                    "--network-mode",
+                    "tun",
+                    "--trust-mode",
+                    "local_ca",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+
+            self.assertEqual(
+                calls_path.read_text(encoding="utf-8").splitlines(),
+                [
+                    "setup rescue --dry-run --json",
+                    "setup repair --dry-run --json",
+                    "setup export-diagnostics --network-mode tun --trust-mode local_ca --json",
+                ],
+            )
 
     def test_agent_protection_smoke_passes_debug_options_from_environment(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
What I did
- Added `scripts/dam-build.sh agent-recovery-smoke` for installed-app recovery validation.
- The command runs read-only recovery probes: `dam setup rescue --dry-run --json`, `dam setup repair --dry-run --json`, and `dam setup export-diagnostics --json`.
- Documented the command in `docs/build-release.md` and covered it with a script-level regression test.

Why I did it
- The release smoke path already covered install/status/protection, but recovery controls were not packaged as a repeatable installed-app smoke step.
- This closes part of the MVP release-smoke gap without mutating local routing or daemon state.

How I did it
- Reused the existing installed-app path, macOS guard, `run` wrapper, and `--network-mode`/`--trust-mode` parsing from `agent-status`.
- Kept the command fail-fast so any recovery probe failure blocks the smoke run.

Branch/PR
- Branch: `chore/agent-recovery-smoke`
- Companion architecture PR: RPBLC-hq/Architecture#9

Tests/results
- RED: `python3 -m unittest tests.test_dam_build_script.DamBuildScriptTests.test_agent_recovery_smoke_runs_read_only_installed_recovery_probes -v` failed before implementation with unknown command.
- GREEN: same targeted test passed after implementation.
- `python3 -m unittest tests.test_dam_build_script -v`
- `scripts/dam-build.sh --help | grep -A2 agent-recovery-smoke`
- `scripts/dam-build.sh agent-check`
- `scripts/dam-build.sh agent-protection-smoke`

Doc/design/TODO sync
- DAM docs updated in `docs/build-release.md`.
- Companion Architecture TODO update tracks read-only recovery smoke coverage and leaves mutating repair/uninstall smoke coverage open.

Risk/failsafe notes
- `agent-recovery-smoke` is read-only: it uses dry-run rescue/repair and diagnostics export only.
- No system network/interception settings are changed by the new command.
- The protection smoke used synthetic PII only against a loopback local upstream.

Next step
- Validate this command on a real notarized installed macOS app, then add explicit mutating repair/uninstall smoke coverage when safe.