### PR TITLE
docs: clarify current install scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ The other side never receives:
 
 ## Install
 
-DAM is built to install in one command on macOS, Linux, and Windows.
+The current MVP install path is staged around the macOS app and the npm/native shims.
+Linux and Windows are design targets, but their routing, trust, tray, and packaging paths
+are still landing in slices. On those platforms, use source builds and explicit proxy
+experiments only; macOS-specific network mutation commands report `unsupported_platform`
+with fallback guidance instead of changing host networking.
 
 ```bash
 npm install -g @rpblc/dam


### PR DESCRIPTION
What I did
- Clarified the README install section so it no longer claims DAM is ready for one-command installation on macOS, Linux, and Windows.
- Documented the current MVP scope as macOS app/npm-native shims, with Linux and Windows still staged.

Why I did it
- The old README wording overstated cross-platform install readiness and conflicted with the current release TODO/platform status.
- This reduces setup confusion for users and agents trying to operationalize DAM today.

How I did it
- Replaced the stale install sentence with a short status paragraph.
- Called out source builds and explicit-proxy experiments as the current non-macOS path.
- Mentioned that macOS-specific mutation commands fail safely with `unsupported_platform` fallback guidance.

Branch/PR
- Branch: `docs/clarify-current-install-scope`

Tests/results
- `git diff --check` passed.
- No code tests run; this is a README-only documentation clarification.

Doc/design/TODO sync
- README now aligns better with the existing DAM platform/status docs and Architecture release TODO.
- No Architecture change was needed because the canonical TODO already tracks Linux/Windows parity and README alignment.

Risk/failsafe notes
- Documentation-only change; no network/interception behavior changed.

Next step
- Review and merge if the wording matches the intended public MVP positioning.
