### PR TITLE
chore: support state-dir release probes

### DIFF
--- a/docs/build-release.md
+++ b/docs/build-release.md
@@ -14,9 +14,9 @@ scripts/dam-build.sh release-macos --mode developer-id
 scripts/dam-build.sh deploy-local --mode development
 scripts/dam-build.sh agent-check
 scripts/dam-build.sh agent-protection-smoke
-scripts/dam-build.sh agent-recovery-smoke --network-mode tun --trust-mode local_ca
+scripts/dam-build.sh agent-recovery-smoke --network-mode tun --trust-mode local_ca [--state-dir PATH]
 scripts/dam-build.sh agent-install --skip-checks
-scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
+scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca [--state-dir PATH]
 ```
 
 `check` runs the repository verification suite: React/Vite UI dependency install and build for the embedded `dam-web` asset, npm package shim smoke tests, npm pack dry-run, Rust formatting, workspace clippy, workspace tests, and macOS Swift package tests when running on macOS.
@@ -37,11 +37,11 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 
 `agent-protection-smoke` runs the local API-through-DAM protection smoke test against a loopback OpenAI-compatible upstream. By default it uses local llama.cpp at `http://127.0.0.1:8080`, builds and runs `target/debug/dam-proxy` on `127.0.0.1:7831`, uses temporary vault/activity SQLite stores, sends synthetic email/SSN values only, verifies trusted-side resolution, verifies the model can transform only DAM references by inserting whitespace after reference opening brackets, checks the activity log for raw synthetic leaks, then terminates the proxy and removes the temporary stores. If `dam-proxy` exits before becoming healthy, the command fails with the captured exit code and stdout/stderr tail so port/config problems are actionable. It does not change system network settings or call paid providers. Set `DAM_AGENT_E2E_BINARY` to test a specific proxy binary, `DAM_AGENT_E2E_BUILD=0` to reuse an existing binary, or `DAM_AGENT_E2E_KEEP_TEMP=1` to retain temporary smoke-test stores for debugging.
 
-`agent-recovery-smoke` runs the installed app's read-only recovery probes without changing routing or daemon state: `dam setup rescue --dry-run --json`, `dam setup repair --dry-run --network-mode <mode> --trust-mode <mode> --json`, and `dam setup export-diagnostics --network-mode <mode> --trust-mode <mode> --json`. It uses the same `--network-mode`, `--trust-mode`, `DAM_AGENT_NETWORK_MODE`, and `DAM_AGENT_TRUST_MODE` inputs as `agent-status` for both setup repair planning and diagnostics export. Use it after `agent-install` when validating that the installed release artifact can explain and preview recovery actions before any mutating rescue/repair is attempted.
+`agent-recovery-smoke` runs the installed app's read-only recovery probes without changing routing or daemon state: `dam setup rescue --dry-run --json`, `dam setup repair --dry-run --network-mode <mode> --trust-mode <mode> --json`, and `dam setup export-diagnostics --network-mode <mode> --trust-mode <mode> --json`. It uses the same `--network-mode`, `--trust-mode`, `--state-dir`, `DAM_AGENT_NETWORK_MODE`, `DAM_AGENT_TRUST_MODE`, and `DAM_AGENT_STATE_DIR` inputs as `agent-status` for setup repair planning and diagnostics export. Use it after `agent-install` when validating that the installed release artifact can explain and preview recovery actions before any mutating rescue/repair is attempted; pass `--state-dir` when validating retained or fixture state instead of the live user state.
 
 `agent-install` is the idempotent local release-path install command for macOS. It optionally runs `agent-check`, builds the app, notarizes Developer ID builds unless notarization is disabled, stops the installed tray/web processes before replacing the app bundle, verifies the installed app, refreshes app-owned System Extension activation, reconfigures the Network Extension manager for `tun` installs, restarts the daemon with the persisted DAM configuration, opens the tray app, and prints `agent-status`.
 
-`agent-status` inspects the installed app without mutating setup. It reports matching DAM processes, verifies code signing, validates notarization/Gatekeeper when notarization is enabled, and runs the installed `dam doctor --json`, `dam setup status --json`, `dam setup next-action --json`, `dam setup export-diagnostics --json`, and `dam status --json` probes. Setup probes default to the release-path `tun` + `local_ca` modes and can be overridden with `--network-mode` and `--trust-mode`. The npm wrapper package doctor remains part of `check`/`agent-check` through the npm smoke test; it is not an installed native app command.
+`agent-status` inspects the installed app without mutating setup. It reports matching DAM processes, verifies code signing, validates notarization/Gatekeeper when notarization is enabled, and runs the installed `dam doctor --json`, `dam setup status --json`, `dam setup next-action --json`, `dam setup export-diagnostics --json`, and `dam status --json` probes. Setup probes default to the release-path `tun` + `local_ca` modes and can be overridden with `--network-mode`, `--trust-mode`, and `--state-dir`/`DAM_AGENT_STATE_DIR` so support and tests can inspect a retained installed state directory without touching the live default. The npm wrapper package doctor remains part of `check`/`agent-check` through the npm smoke test; it is not an installed native app command.
 
 ## Environment
 
@@ -57,6 +57,7 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
 - `DAM_AGENT_STATUS_STRICT`: set to `1` to make `agent-status` fail when any probe fails.
 - `DAM_AGENT_NETWORK_MODE`: setup mode for `agent-status`, default `tun`.
 - `DAM_AGENT_TRUST_MODE`: trust mode for `agent-status`, default `local_ca`.
+- `DAM_AGENT_STATE_DIR`: optional state directory for installed-app `agent-status` and `agent-recovery-smoke` probes.
 - `DAM_AGENT_E2E_UPSTREAM`: local OpenAI-compatible upstream for `agent-protection-smoke`, default `http://127.0.0.1:8080`.
 - `DAM_AGENT_E2E_LISTEN`: loopback listen address for the smoke proxy, default `127.0.0.1:7831`.
 - `DAM_AGENT_E2E_STARTUP_TIMEOUT`: smoke proxy startup timeout in seconds, default `30`.

--- a/scripts/dam-build.sh
+++ b/scripts/dam-build.sh
@@ -12,6 +12,7 @@ RESTART_AFTER_INSTALL="${DAM_RESTART_AFTER_INSTALL:-1}"
 AGENT_STATUS_STRICT="${DAM_AGENT_STATUS_STRICT:-0}"
 AGENT_NETWORK_MODE="${DAM_AGENT_NETWORK_MODE:-tun}"
 AGENT_TRUST_MODE="${DAM_AGENT_TRUST_MODE:-local_ca}"
+AGENT_STATE_DIR="${DAM_AGENT_STATE_DIR:-}"
 AGENT_E2E_UPSTREAM="${DAM_AGENT_E2E_UPSTREAM:-http://127.0.0.1:8080}"
 AGENT_E2E_LISTEN="${DAM_AGENT_E2E_LISTEN:-127.0.0.1:7831}"
 AGENT_E2E_STARTUP_TIMEOUT="${DAM_AGENT_E2E_STARTUP_TIMEOUT:-30}"
@@ -56,6 +57,7 @@ Options:
   --strict-status                  Make agent-status fail when a status probe fails
   --network-mode MODE              Setup mode used by agent-status probes
   --trust-mode MODE                Trust mode used by agent-status probes
+  --state-dir DIR                  State directory used by setup/doctor probes
   -h, --help                       Show this help
 
 Environment:
@@ -71,6 +73,7 @@ Environment:
   DAM_AGENT_STATUS_STRICT   Set to 1 to make agent-status fail on probe errors
   DAM_AGENT_NETWORK_MODE    Setup mode for agent-status, currently tun
   DAM_AGENT_TRUST_MODE      Trust mode for agent-status, currently local_ca
+  DAM_AGENT_STATE_DIR       Optional state directory for setup/doctor probes
   DAM_AGENT_E2E_UPSTREAM    Local OpenAI-compatible smoke upstream, currently $AGENT_E2E_UPSTREAM
   DAM_AGENT_E2E_LISTEN      Loopback listen address for smoke proxy, currently $AGENT_E2E_LISTEN
   DAM_AGENT_E2E_STARTUP_TIMEOUT
@@ -363,6 +366,9 @@ cmd_agent_status() {
   printf 'app: %s\n' "$app"
   printf 'setup_probe_network_mode: %s\n' "$AGENT_NETWORK_MODE"
   printf 'setup_probe_trust_mode: %s\n' "$AGENT_TRUST_MODE"
+  if [[ -n "$AGENT_STATE_DIR" ]]; then
+    printf 'setup_probe_state_dir: %s\n' "$AGENT_STATE_DIR"
+  fi
   if [[ ! -d "$app" ]]; then
     echo "installed app not found"
     exit 1
@@ -382,10 +388,14 @@ cmd_agent_status() {
     status_try failures xcrun stapler validate "$app"
     status_try failures spctl -a -vvv -t exec "$app"
   fi
-  status_try failures "$dam_bin" doctor --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
-  status_try failures "$dam_bin" setup status --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
-  status_try failures "$dam_bin" setup next-action --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
-  status_try failures "$dam_bin" setup export-diagnostics --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
+  local state_args=()
+  if [[ -n "$AGENT_STATE_DIR" ]]; then
+    state_args=(--state-dir "$AGENT_STATE_DIR")
+  fi
+  status_try failures "$dam_bin" doctor --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" "${state_args[@]}" --json
+  status_try failures "$dam_bin" setup status --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" "${state_args[@]}" --json
+  status_try failures "$dam_bin" setup next-action --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" "${state_args[@]}" --json
+  status_try failures "$dam_bin" setup export-diagnostics --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" "${state_args[@]}" --json
   status_try failures "$dam_bin" status --json
 
   printf 'status_probe_failures: %s\n' "$failures"
@@ -403,6 +413,9 @@ cmd_agent_recovery_smoke() {
   printf 'app: %s\n' "$app"
   printf 'setup_probe_network_mode: %s\n' "$AGENT_NETWORK_MODE"
   printf 'setup_probe_trust_mode: %s\n' "$AGENT_TRUST_MODE"
+  if [[ -n "$AGENT_STATE_DIR" ]]; then
+    printf 'setup_probe_state_dir: %s\n' "$AGENT_STATE_DIR"
+  fi
 
   if [[ ! -d "$app" ]]; then
     echo "installed app not found" >&2
@@ -415,9 +428,13 @@ cmd_agent_recovery_smoke() {
     exit 1
   fi
 
-  run "$dam_bin" setup rescue --dry-run --json
-  run "$dam_bin" setup repair --dry-run --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
-  run "$dam_bin" setup export-diagnostics --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" --json
+  local state_args=()
+  if [[ -n "$AGENT_STATE_DIR" ]]; then
+    state_args=(--state-dir "$AGENT_STATE_DIR")
+  fi
+  run "$dam_bin" setup rescue --dry-run "${state_args[@]}" --json
+  run "$dam_bin" setup repair --dry-run --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" "${state_args[@]}" --json
+  run "$dam_bin" setup export-diagnostics --network-mode "$AGENT_NETWORK_MODE" --trust-mode "$AGENT_TRUST_MODE" "${state_args[@]}" --json
 }
 
 cmd_agent_install() {
@@ -517,6 +534,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --trust-mode)
       AGENT_TRUST_MODE="${2:?--trust-mode requires a value}"
+      shift 2
+      ;;
+    --state-dir)
+      AGENT_STATE_DIR="${2:?--state-dir requires a directory}"
       shift 2
       ;;
     -h|--help)

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -28,6 +28,7 @@ class DamBuildScriptTests(unittest.TestCase):
         self.assertIn("DAM_AGENT_E2E_BINARY", result.stdout)
         self.assertIn("DAM_AGENT_E2E_BUILD", result.stdout)
         self.assertIn("DAM_AGENT_E2E_KEEP_TEMP", result.stdout)
+        self.assertIn("DAM_AGENT_STATE_DIR", result.stdout)
 
     def test_agent_protection_smoke_invokes_local_smoke_script_with_safe_defaults(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -143,6 +144,7 @@ class DamBuildScriptTests(unittest.TestCase):
             app_dir = temp_path / "DAM.app"
             dam_bin = app_dir / "Contents" / "MacOS" / "dam"
             calls_path = temp_path / "dam-calls.txt"
+            state_dir = temp_path / "state"
             bin_dir.mkdir()
             dam_bin.parent.mkdir(parents=True)
 
@@ -173,6 +175,7 @@ class DamBuildScriptTests(unittest.TestCase):
                 {
                     "DAM_INSTALL_DIR": str(temp_path),
                     "DAM_SIGN_MODE": "development",
+                    "DAM_AGENT_STATE_DIR": str(state_dir),
                     "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
                 }
             )
@@ -194,7 +197,7 @@ class DamBuildScriptTests(unittest.TestCase):
             )
 
             self.assertIn(
-                "setup export-diagnostics --network-mode tun --trust-mode local_ca --json",
+                f"setup export-diagnostics --network-mode tun --trust-mode local_ca --state-dir {state_dir} --json",
                 calls_path.read_text(encoding="utf-8").splitlines(),
             )
 
@@ -205,6 +208,7 @@ class DamBuildScriptTests(unittest.TestCase):
             app_dir = temp_path / "DAM.app"
             dam_bin = app_dir / "Contents" / "MacOS" / "dam"
             calls_path = temp_path / "dam-calls.txt"
+            state_dir = temp_path / "state"
             bin_dir.mkdir()
             dam_bin.parent.mkdir(parents=True)
 
@@ -227,6 +231,7 @@ class DamBuildScriptTests(unittest.TestCase):
             env.update(
                 {
                     "DAM_INSTALL_DIR": str(temp_path),
+                    "DAM_AGENT_STATE_DIR": str(state_dir),
                     "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
                 }
             )
@@ -250,9 +255,9 @@ class DamBuildScriptTests(unittest.TestCase):
             self.assertEqual(
                 calls_path.read_text(encoding="utf-8").splitlines(),
                 [
-                    "setup rescue --dry-run --json",
-                    "setup repair --dry-run --network-mode tun --trust-mode local_ca --json",
-                    "setup export-diagnostics --network-mode tun --trust-mode local_ca --json",
+                    f"setup rescue --dry-run --state-dir {state_dir} --json",
+                    f"setup repair --dry-run --network-mode tun --trust-mode local_ca --state-dir {state_dir} --json",
+                    f"setup export-diagnostics --network-mode tun --trust-mode local_ca --state-dir {state_dir} --json",
                 ],
             )
 


### PR DESCRIPTION
What I did
- Added optional `--state-dir` / `DAM_AGENT_STATE_DIR` support to `scripts/dam-build.sh agent-status` setup/doctor probes.
- Reused the same state-dir context for `agent-recovery-smoke` rescue dry-run, repair dry-run, and diagnostics export probes.
- Updated DAM release docs and script regression tests.

Why I did it
- Release-path recovery validation needs to inspect retained or fixture installed state safely, without accidentally reading or mutating the live default DAM state.
- This makes installed-app recovery probes easier for agents and maintainers to run against a specific failed setup snapshot.

How I did it
- Built state-dir arguments once per workflow and passed them through to installed `dam doctor` and `dam setup ...` probes.
- Added Python regression coverage using a temp installed-app/stub `dam` binary to prove state-dir propagation.
- Kept the workflow non-mutating: recovery smoke still only uses dry-run rescue/repair and diagnostics export.

Branch/PR
- Branch: `chore/agent-state-dir-release-probes`
- Companion Architecture PR: RPBLC-hq/Architecture#11

Tests/results
- `python3 -m unittest tests/test_dam_build_script.py -v`
- `scripts/dam-build.sh agent-check`
- `git diff --check` in Architecture
- Local API-through-DAM protection smoke was not run because this change only affects release/status shell probe routing and docs; it does not change proxy/privacy filtering behavior.

Doc/design/TODO sync
- Updated `docs/build-release.md`.
- Updated canonical Architecture release workflow in RPBLC-hq/Architecture#11.

Risk/failsafe notes
- No DAM network interception, routing, daemon, or host configuration changes were executed.
- The new flag is opt-in; existing release-probe behavior is unchanged when no state dir is provided.

Next step
- Review and merge with the companion Architecture PR if checks/reviews are clear.
