### PR TITLE
fix: mark unsupported tun fallback non-mutating

### DIFF
--- a/crates/dam-diagnostics/src/lib.rs
+++ b/crates/dam-diagnostics/src/lib.rs
@@ -897,7 +897,7 @@ fn platform_capture_planned_step(kind: SetupStepKind, message: &str) -> SetupSte
             "disabled".to_string(),
         ]),
         requires_confirmation: false,
-        changes_system: true,
+        changes_system: false,
     }
 }
 

--- a/crates/dam-diagnostics/src/lib_tests.rs
+++ b/crates/dam-diagnostics/src/lib_tests.rs
@@ -575,6 +575,10 @@ fn tun_capture_setup_steps_are_platform_specific_for_linux_and_windows() {
             "disabled".to_string()
         ])
     );
+    assert!(!linux_steps[0].requires_confirmation);
+    assert!(!linux_steps[0].changes_system);
+    assert!(!windows_steps[0].requires_confirmation);
+    assert!(!windows_steps[0].changes_system);
 }
 
 #[cfg(target_os = "macos")]

--- a/docs/dam-diagnostics.md
+++ b/docs/dam-diagnostics.md
@@ -29,6 +29,7 @@ Status: implemented first extraction.
   macOS emits System Extension approval, reboot, Network Extension manager configuration, manager enablement, and manager connection as separate steps;
   Linux emits a Linux transparent routing step and currently blocks to explicit proxy mode until that backend lands;
   Windows emits a Windows Filtering Platform step and currently blocks to explicit proxy mode until that backend lands;
+  unsupported-platform fallback commands are marked as non-system-mutating because they switch to explicit-proxy daemon setup rather than installing routing or trust state;
 - local CA trust readiness when requested;
 - daemon lifecycle readiness for the requested network/trust modes.
 


### PR DESCRIPTION
What I did
- Marked unsupported Linux/Windows `tun` fallback setup steps as non-system-mutating.
- Added diagnostics regression coverage for the `requires_confirmation: false` and `changes_system: false` contract.
- Updated DAM diagnostics docs to describe the fallback safety boundary.

Why I did it
- Unsupported transparent capture paths should guide users/agents back to explicit-proxy mode without implying a routing/trust mutation is about to happen.
- This makes setup status safer and clearer on non-macOS platforms while native transparent capture remains planned.

How I did it
- Changed `platform_capture_planned_step` in `dam-diagnostics` to emit `changes_system: false`.
- Extended the Linux/Windows planned-backend unit test to lock the contract.
- Kept the Architecture companion doc in sync.

Branch/PR
- Branch: `fix/unsupported-tun-fallback-safety`
- Companion Architecture PR: RPBLC-hq/Architecture#13

Tests/results
- RED: `cargo test -p dam-diagnostics tun_capture_setup_steps_are_platform_specific_for_linux_and_windows` failed before implementation on `changes_system`.
- GREEN: `cargo test -p dam-diagnostics` passed.
- Full local verification: `scripts/dam-build.sh agent-check` passed.
- Protection smoke: `scripts/dam-build.sh agent-protection-smoke` passed with loopback synthetic PII before this small diagnostics change; no network routing mutation was performed.

Doc/design/TODO sync
- DAM docs updated.
- Companion Architecture PR updates `dam/diagnostics.md`.
- No TODO checkbox changed; this is a small safety hardening toward the unsupported-platform fallback item, not the full Linux/Windows parity milestone.

Risk/failsafe notes
- No host network/interception configuration was changed.
- The fallback command remains explicit-proxy setup guidance and does not install routing/trust state.

Next step
- Review and merge Architecture companion first, then this DAM PR when checks are clear.
