### PR TITLE
docs: align DAM web and quick-start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ setup, trust, and routing — no flags to memorize.
 dam-tray
 ```
 
-Click the `[R:]` menu-bar item and hit **Connect**. To confirm DAM is
-mediating:
+Click the `[R:]` menu-bar item and hit **Connect**. To inspect the full
+idempotent setup checklist or the running daemon state:
 
 ```bash
+dam setup status --json
 dam status --json
 ```
 

--- a/docs/dam-web.md
+++ b/docs/dam-web.md
@@ -9,11 +9,15 @@ The app frame is a React shell served from embedded `/assets/bundle.js`, `/asset
 ## Current Routes
 
 ```text
-/                 Connect surface
+/                 smart landing: web redirects to /insights when protected, /connect otherwise; tray stays on /connect
 /connect          Connect surface
+/insights         web privacy-dividend dashboard
+/wallet           local Wallet and allowed-consent roster
 /allowed          compatibility redirect to /wallet?state=allowed
 /activity         dam-log derived activity feed
 /settings         local preferences, integrations, and daemon controls
+/system           web-only operator system log
+/health           web-only doctor/diagnostics health surface
 /*                frame fallback
 ```
 


### PR DESCRIPTION
What I did
- Updated `docs/dam-web.md` so the documented route list matches the current React router.
- Clarified the `/` smart landing behavior and added the implemented `/insights`, `/wallet`, `/system`, and `/health` routes.
- Clarified the README quick start so first-run users and agents inspect both the setup checklist (`dam setup status --json`) and the running daemon state (`dam status --json`).

Why I did it
- The docs still described `/` as only Connect and omitted several shipped surfaces, which makes the install/use path harder for agents and operators to reason about.
- The README quick start only mentioned daemon status, but the operationalized install path also depends on the setup checklist contract.
- Architecture already describes these surfaces and setup/status contracts, so this is DAM docs drift cleanup rather than a contract change.

How I did it
- Verified the live route definitions in `crates/dam-web/ui/src/app/router.tsx`.
- Verified the live CLI synopsis for `dam setup status --help` and `dam status --help`.
- Edited only DAM documentation.

Branch/PR
- Branch: `docs/web-route-docs`
- PR: RPBLC-hq/DAM#102
- Companion Architecture PR: none needed; Architecture already lists these routes/surfaces and setup/status commands.

Tests/results
- `git diff --check`
- `cargo run -q -p dam -- setup status --help`
- `cargo run -q -p dam -- status --help`

Doc/design/TODO sync
- DAM docs updated.
- No Architecture change needed because `dam/web/requirements.md` and `dam/launcher.md` already state the current route/surface and setup/status contracts.
- No TODO checkbox was closed.

Risk/failsafe notes
- Docs-only change.
- No code tests or protection smoke were run because no code, config, routing, interception, or privacy-filter behavior changed.

Next step
- Review and merge only after Alexy approval.
