### PR TITLE
docs: tighten README MVP profile wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,12 @@ cargo build -p dam -p dam-web -p dam-tray
 cargo run -p dam-tray
 ```
 
-Headless setup, app profiles (Claude, ChatGPT, …), and every routing/trust
-flag are in [docs/dam.md](docs/dam.md),
+Headless setup, the MVP-visible app profiles (Claude and ChatGPT), and every
+routing/trust flag are in [docs/dam.md](docs/dam.md),
 [docs/dam-tray.md](docs/dam-tray.md), and
-[docs/dam-integrations.md](docs/dam-integrations.md).
+[docs/dam-integrations.md](docs/dam-integrations.md). Imported/custom profile
+JSON remains opt-in and is documented in those module docs rather than treated
+as part of the default visible MVP catalog.
 
 ## How It Works
 


### PR DESCRIPTION
What I did
- Tightened the DAM README wording for the top-level app-profile surface.
- Replaced the open-ended `Claude, ChatGPT, …` phrasing with the shipped MVP-visible catalog: Claude and ChatGPT.
- Clarified that imported/custom profile JSON remains opt-in and is documented in the module docs rather than treated as part of the default visible MVP catalog.

Why I did it
- The README should state the current MVP surface exactly, not imply a broader visible profile catalog than the product currently ships.
- This keeps the top-level docs aligned with the implemented DAM docs for `dam connect`, Settings, and profile defaults.

How I did it
- Updated `README.md` only.
- Verified the new wording against `docs/dam.md`, `docs/dam-web.md`, and `docs/dam-integrations.md`.

Closes RPBLC-hq/Architecture#22

Tests / verification
- `git diff --check`
- Coherence read against `docs/dam.md`, `docs/dam-web.md`, and `docs/dam-integrations.md`
- No code tests or protection smoke were run because this is a docs-only README clarification with no code, config, or contract change.

Risk / failsafe notes
- Docs-only change; no runtime, network, or setup behavior changed.
- No Architecture companion PR was needed because the canonical DAM Architecture docs already match the shipped profile/default behavior; this change only removes stale wording from the implementation repo README.

Next step
- Ready for review.
