### PR TITLE
docs: add DAM security review bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Full pipeline, resolve path, and control/diagnostics flows are in
 | Use the web UI / tray | [docs/dam-web.md](docs/dam-web.md) · [docs/dam-tray.md](docs/dam-tray.md) |
 | Drive DAM from an agent | [docs/dam-mcp.md](docs/dam-mcp.md) · [docs/dam-api.md](docs/dam-api.md) |
 | What's detected | [docs/dam-detect.md](docs/dam-detect.md) · [docs/dam-policy.md](docs/dam-policy.md) |
+| Prepare a security review | [docs/security-review-bundle.md](docs/security-review-bundle.md) |
 | Build & release | [docs/build-release.md](docs/build-release.md) |
 | Module map & architecture | [docs/README.md](docs/README.md) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,10 @@ Deferred security and product-design work is tracked in [parking-lot.md](parking
 
 DAM is designed for macOS, Linux, and Windows. Platform-specific routing, trust, tray, and packaging implementations may land in staged slices, but partial or delayed platform behavior must be tracked in [parking-lot.md](parking-lot.md) or the relevant module parking-lot doc.
 
+## Operational Guides
+
+- [security-review-bundle](security-review-bundle.md): local synthetic-data-only trust/evidence checklist for reviewers.
+
 ## Modules
 
 - [dam-core](dam-core.md): shared contracts, reference generation, replacement planning, policy actions, log event shape.

--- a/docs/dam-e2e.md
+++ b/docs/dam-e2e.md
@@ -53,6 +53,13 @@ python3 scripts/rpblc_dam_local_llm_e2e_smoke.py --upstream http://127.0.0.1:808
 
 The script builds `dam-proxy`, starts it on loopback with temporary vault/log SQLite files, sends synthetic email/SSN values through DAM to the local OpenAI-compatible upstream, verifies exact echo resolution on the trusted client side, verifies a token-transformation prompt that asks the model to insert whitespace after reference opening brackets cannot reconstruct the raw values, fails if the local activity log database contains the synthetic values, and removes the temp directory unless `--keep-temp` is passed. Exit code `2` means the local upstream or binary prerequisite is unavailable; exit code `1` means DAM failed the smoke check.
 
+When no local model endpoint is listening, use the deterministic loopback fake upstream instead of skipping the proxy path:
+
+```bash
+python3 scripts/dam_fake_openai_upstream.py --port 18080
+DAM_AGENT_E2E_UPSTREAM=http://127.0.0.1:18080 scripts/dam-build.sh agent-protection-smoke
+```
+
 ## Rules
 
 - Use synthetic data only.

--- a/docs/security-review-bundle.md
+++ b/docs/security-review-bundle.md
@@ -1,0 +1,167 @@
+# DAM Security Review Bundle
+
+This guide gives a reviewer one local, synthetic-data-only path to gather DAM trust evidence without implying compliance certification, enterprise DLP replacement, or universal leak prevention.
+
+## What this bundle is
+
+Use this bundle when you want a small reproducible answer to:
+
+- does DAM replace supported sensitive values before upstream egress?
+- can contributors inspect detector quality without real secrets?
+- do current smoke checks fail closed on raw-value leakage in non-vault surfaces?
+- can the installed app explain setup and recovery state without immediately mutating the host?
+- what current build/release posture exists today?
+
+## What this bundle is not
+
+This bundle supports local technical review. It is **not**:
+
+- a SOC 2 report;
+- a GDPR/compliance certification claim;
+- proof that DAM prevents all data leakage;
+- proof for unsupported traffic types or unsupported sensitive-value kinds;
+- a substitute for your own security review, threat model, or deployment controls.
+
+## Entry point
+
+Start here from a DAM checkout:
+
+```bash
+git diff --check
+scripts/dam-build.sh detector-bench
+python3 scripts/dam_fake_openai_upstream.py --port 18080
+DAM_AGENT_E2E_UPSTREAM=http://127.0.0.1:18080 scripts/dam-build.sh agent-protection-smoke
+```
+
+Keep the fake upstream running only for the protection smoke, then stop it.
+
+## Bundle sections
+
+### 1. Protection smoke
+
+Goal: prove supported synthetic values are replaced before a loopback upstream receives them, while the trusted local client still gets the resolved response.
+
+Use a local OpenAI-compatible endpoint if you already have one:
+
+```bash
+scripts/dam-build.sh agent-protection-smoke
+```
+
+If no local model is listening, use the deterministic loopback fake upstream:
+
+```bash
+python3 scripts/dam_fake_openai_upstream.py --port 18080
+DAM_AGENT_E2E_UPSTREAM=http://127.0.0.1:18080 scripts/dam-build.sh agent-protection-smoke
+```
+
+Current evidence boundary:
+
+- loopback only;
+- synthetic email + SSN fixtures only;
+- no paid provider calls;
+- verifies upstream tokenization, trusted-side exact echo, adversarial token transformation, and non-vault activity-log raw-value absence.
+
+### 2. Detector benchmark
+
+Goal: show current supported detector coverage and false-positive/false-negative behavior on synthetic fixtures.
+
+```bash
+scripts/dam-build.sh detector-bench
+cargo run -q -p dam-detect-bench -- --format json
+```
+
+Current evidence boundary:
+
+- benchmark results are only for the detector families and fixtures currently shipped;
+- strong benchmark results do not imply protection for unsupported kinds.
+
+### 3. Raw-value leakage boundary
+
+Goal: show that current smoke coverage fails closed if synthetic raw values appear outside intentional local reveal surfaces.
+
+Current executable proof path:
+
+```bash
+python3 scripts/dam_fake_openai_upstream.py --port 18080
+DAM_AGENT_E2E_UPSTREAM=http://127.0.0.1:18080 scripts/dam-build.sh agent-protection-smoke
+```
+
+What that proves today:
+
+- the upstream did not receive the raw synthetic values;
+- the smoke's activity-log scan fails if the temporary non-vault log store contains the raw synthetic values.
+
+Current limitation:
+
+- richer Connect / Activity surface verification is still tracked separately and should not be described as shipped here unless the corresponding visible-evidence proof path is merged and rerun on the reviewed head.
+
+### 4. Setup and recovery posture
+
+Goal: show that installed-app setup state and recovery guidance are inspectable before running mutating repair flows.
+
+Installed-app inspection commands:
+
+```bash
+scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca
+scripts/dam-build.sh agent-recovery-smoke --network-mode tun --trust-mode local_ca
+```
+
+Optional retained/fixture state inspection:
+
+```bash
+scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca --state-dir /path/to/state
+scripts/dam-build.sh agent-recovery-smoke --network-mode tun --trust-mode local_ca --state-dir /path/to/state
+```
+
+Current evidence boundary:
+
+- these are installed-app release-path checks;
+- `agent-recovery-smoke` is read-only;
+- mutating recovery remains explicitly gated behind `agent-repair-smoke --confirm-mutation` and should only run on disposable or explicitly approved state.
+
+Platform boundary:
+
+- the installed app flow is currently the macOS release path; on Linux/Windows, do not claim equivalent packaged recovery posture until those release paths exist.
+
+### 5. Build / release posture
+
+Goal: show what local maintainers can verify today about build hygiene and release preparation.
+
+```bash
+scripts/dam-build.sh agent-check
+scripts/dam-build.sh release-macos --mode developer-id
+```
+
+Current evidence boundary:
+
+- `agent-check` covers repository verification and whitespace checks;
+- `release-macos` covers the macOS signed/notarized artifact path when the required credentials are configured;
+- this is build/release evidence, not a supply-chain attestation, SBOM, or certification claim.
+
+### 6. Claim boundary text
+
+Safe summary wording:
+
+> DAM provides local technical evidence that supported synthetic sensitive values were replaced before supported AI/agent traffic reached a configured loopback or local upstream, and that the current smoke path checks non-vault temporary log storage for raw synthetic-value leakage.
+
+Avoid wording like:
+
+- “DAM is SOC 2 compliant”;
+- “DAM makes AI usage GDPR compliant”;
+- “DAM prevents all leakage”;
+- “DAM replaces enterprise DLP”; or
+- “DAM completes vendor risk review.”
+
+## Suggested reviewer note template
+
+```text
+Reviewed with local synthetic-data-only DAM evidence.
+Ran: git diff --check, detector-bench, agent-protection-smoke via loopback upstream, and the relevant installed-app status/recovery probes.
+Observed: DAM proof is bounded to supported traffic/kinds and current local smoke checks; no compliance/certification claim implied.
+```
+
+## Related docs
+
+- [build-release.md](build-release.md)
+- [dam-detect.md](dam-detect.md)
+- [dam-e2e.md](dam-e2e.md)

--- a/scripts/dam_fake_openai_upstream.py
+++ b/scripts/dam_fake_openai_upstream.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Deterministic loopback OpenAI-compatible fake upstream for DAM smoke tests.
+
+Implements the tiny API surface needed by `scripts/dam-build.sh agent-protection-smoke`:
+- GET /v1/models
+- POST /v1/chat/completions
+
+The handler echoes exact-echo prompts and deliberately breaks DAM reference syntax for
+adversarial token-transformation prompts. Keep this loopback-only and synthetic-data-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "DamFakeOpenAI/0.1"
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def _send_json(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        if self.path == "/v1/models":
+            self._send_json(200, {"object": "list", "data": [{"id": "fake-deterministic"}]})
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        length = int(self.headers.get("content-length") or 0)
+        raw = self.rfile.read(length)
+        try:
+            data = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            data = {}
+
+        user_content = ""
+        for message in reversed(data.get("messages") or []):
+            if message.get("role") == "user":
+                user_content = str(message.get("content") or "")
+                break
+
+        if "Text:" in user_content:
+            content = user_content.split("Text:", 1)[1].strip()
+            content = content.replace("[email:", "[ email:").replace("[ssn:", "[ ssn:")
+        elif "alpha=" in user_content:
+            content = user_content[user_content.index("alpha=") :].strip()
+        else:
+            content = user_content
+
+        self._send_json(
+            200,
+            {
+                "id": "chatcmpl-fake",
+                "object": "chat.completion",
+                "model": "fake-deterministic",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=18080)
+    args = parser.parse_args()
+    ThreadingHTTPServer((args.host, args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dam_fake_openai_upstream.py
+++ b/tests/test_dam_fake_openai_upstream.py
@@ -1,0 +1,94 @@
+import importlib.util
+import json
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "dam_fake_openai_upstream.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("dam_fake_openai_upstream", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class DamFakeOpenAiUpstreamTests(unittest.TestCase):
+    def test_models_endpoint_returns_fake_model(self):
+        fake = load_module()
+        server = ThreadingHTTPServer(("127.0.0.1", 0), fake.Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{server.server_port}/v1/models") as response:
+                payload = json.load(response)
+            self.assertEqual(payload["data"][0]["id"], "fake-deterministic")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+    def test_chat_completion_echoes_exact_prompt_suffix(self):
+        fake = load_module()
+        server = ThreadingHTTPServer(("127.0.0.1", 0), fake.Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            body = json.dumps(
+                {
+                    "model": "local",
+                    "messages": [
+                        {"role": "user", "content": "Repeat exactly. alpha=one beta=two"}
+                    ],
+                }
+            ).encode("utf-8")
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{server.server_port}/v1/chat/completions",
+                data=body,
+                headers={"content-type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request) as response:
+                payload = json.load(response)
+            self.assertEqual(payload["choices"][0]["message"]["content"], "alpha=one beta=two")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+    def test_chat_completion_breaks_dam_reference_open_brackets_for_transform_prompt(self):
+        fake = load_module()
+        server = ThreadingHTTPServer(("127.0.0.1", 0), fake.Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            content = "Insert one space after the opening bracket in every DAM token. Text: [email:abc] [ssn:def]"
+            body = json.dumps(
+                {
+                    "model": "local",
+                    "messages": [{"role": "user", "content": content}],
+                }
+            ).encode("utf-8")
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{server.server_port}/v1/chat/completions",
+                data=body,
+                headers={"content-type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request) as response:
+                payload = json.load(response)
+            self.assertEqual(payload["choices"][0]["message"]["content"], "[ email:abc] [ ssn:def]")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What I did
- Added a focused `docs/security-review-bundle.md` guide that gives reviewers one synthetic-data-only entry point for DAM trust evidence.
- Added a reusable deterministic loopback fake upstream at `scripts/dam_fake_openai_upstream.py` plus focused tests so the protection smoke has an exact fallback command when no local model is listening.
- Linked the new guide from `README.md`, `docs/README.md`, and `docs/dam-e2e.md`.

Why I did it
- Architecture issue #31 asked for the first DAM security-review bundle artifact: a small, reproducible evidence path that reduces reviewer adoption friction without overclaiming compliance or universal protection.
- The existing protection and detector proof paths were already useful, but the repo did not yet give reviewers a single checklist or an in-repo deterministic fake-upstream helper they could run directly.

How I did it
- Kept the change small and local to the DAM repo: docs + a tiny loopback-only helper script + focused tests.
- Reused the existing proof anchors (`detector-bench`, `agent-protection-smoke`) instead of inventing new protection behavior.
- Bounded the guide language to supported traffic/kinds and current executable evidence only.

## Summary
- add a dedicated DAM security-review bundle guide
- add a deterministic fake OpenAI-compatible upstream helper for protection smoke fallback
- document the exact fallback smoke commands in DAM docs

## Test Plan
- `git diff --check`
- `python3 -m py_compile scripts/dam_fake_openai_upstream.py`
- `python3 -m unittest tests.test_dam_fake_openai_upstream tests.test_local_llm_e2e_smoke_script`
- `scripts/dam-build.sh detector-bench`
- `DAM_AGENT_E2E_UPSTREAM=http://127.0.0.1:18080 scripts/dam-build.sh agent-protection-smoke`

## Results
- `detector-bench` passed with `tp=20 fp=0 fn=0 precision=1.000 recall=1.000 f1=1.000`.
- `agent-protection-smoke` passed against the deterministic loopback fake upstream and reported `raw_synthetic_values_in_local_activity_log: []`.
- The helper process was stopped after verification.

## Docs / Architecture sync
- DAM docs updated in this PR.
- No Architecture companion PR needed: this change documents existing proof paths and adds a local helper script, but does not change the DAM CLI/API/release contract.

## Risk / failsafe notes
- Loopback only; synthetic data only; no paid upstreams.
- The new helper script implements only `GET /v1/models` and `POST /v1/chat/completions` for local smoke fallback.
- The guide explicitly avoids SOC/GDPR/certification/zero-leakage claims.

Closes RPBLC-hq/Architecture#31
