### PR TITLE
feat: add npm readiness probe

### DIFF
--- a/docs/build-release.md
+++ b/docs/build-release.md
@@ -13,6 +13,7 @@ scripts/dam-build.sh notarize --app target/dam-build/macos/DAM.app --notary-prof
 scripts/dam-build.sh release-macos --mode developer-id
 scripts/dam-build.sh deploy-local --mode development
 scripts/dam-build.sh agent-check
+scripts/dam-build.sh agent-npm-readiness
 scripts/dam-build.sh agent-protection-smoke
 scripts/dam-build.sh agent-recovery-smoke --network-mode tun --trust-mode local_ca [--state-dir PATH]
 scripts/dam-build.sh agent-repair-smoke --network-mode tun --trust-mode local_ca --confirm-mutation [--state-dir PATH]
@@ -35,6 +36,8 @@ scripts/dam-build.sh agent-status --network-mode tun --trust-mode local_ca [--st
 `deploy-local` builds or accepts an existing `DAM.app` and copies it to `/Applications` by default.
 
 `agent-check` is the default verification command for local agents and maintainers. It runs `check` and adds `git diff --check` when the source tree is a git checkout.
+
+`agent-npm-readiness` is the local/read-only npm installability probe. It stages current-platform native binaries under `npm/native/<platform>-<arch>/`, runs `dam package-doctor --json`, verifies that `npm pack --dry-run --ignore-scripts --json` includes the staged binaries, reports the current registry owner and published version for `@rpblc/dam`, and fails closed when the local package version is not publishable or this machine lacks npm publish auth. It does not publish, mutate system routing/trust, or require package credentials in repository files.
 
 `agent-protection-smoke` runs the local API-through-DAM protection smoke test against a loopback OpenAI-compatible upstream. By default it uses local llama.cpp at `http://127.0.0.1:8080`, builds and runs `target/debug/dam-proxy` on `127.0.0.1:7831`, uses temporary vault/activity SQLite stores, sends synthetic email/SSN values only, verifies trusted-side resolution, verifies the model can transform only DAM references by inserting whitespace after reference opening brackets, checks the activity log for raw synthetic leaks, then terminates the proxy and removes the temporary stores. If `dam-proxy` exits before becoming healthy, the command fails with the captured exit code and stdout/stderr tail so port/config problems are actionable. It does not change system network settings or call paid providers. Set `DAM_AGENT_E2E_BINARY` to test a specific proxy binary, `DAM_AGENT_E2E_BUILD=0` to reuse an existing binary, or `DAM_AGENT_E2E_KEEP_TEMP=1` to retain temporary smoke-test stores for debugging.
 

--- a/docs/dam.md
+++ b/docs/dam.md
@@ -130,7 +130,7 @@ dam disconnect
 
 The npm package entry point is a small Node wrapper around native DAM binaries. It does not own protection behavior.
 
-The package exposes shims for `dam`, `damctl`, `dam-web`, `dam-proxy`, `dam-mcp`, and `dam-tray`. `dam package-doctor --json` validates that the installed shims resolve to native binaries. `dam doctor --json` is forwarded to the native `dam` binary and reports local readiness.
+The package exposes shims for `dam`, `damctl`, `dam-web`, `dam-proxy`, `dam-mcp`, and `dam-tray`. `dam package-doctor --json` validates that the installed shims resolve to native binaries. `dam doctor --json` is forwarded to the native `dam` binary and reports local readiness. `scripts/dam-build.sh agent-npm-readiness` is the maintainer-side probe that stages current-platform native binaries, verifies the `npm pack --dry-run --ignore-scripts --json` payload, and reports registry/auth blockers without publishing.
 
 The previous one-shot `npx @rpblc/dam claude` and `npx @rpblc/dam codex --api` trial launchers have been removed because they depended on provider base-url rewriting. Use the installed `dam connect` / tray flow for protected traffic interception.
 

--- a/scripts/dam-build.sh
+++ b/scripts/dam-build.sh
@@ -37,6 +37,8 @@ Commands:
   release-macos Run checks, build signed DAM.app, notarize, staple, and zip it
   deploy-local  Build signed DAM.app and copy it to /Applications or --install-dir
   agent-check   Run the standard verification suite plus repo whitespace checks
+  agent-npm-readiness
+               Stage npm native binaries, validate the package payload, and report publish blockers
   detector-bench
                 Run the synthetic DAM detector benchmark harness
   agent-protection-smoke
@@ -257,6 +259,149 @@ cmd_agent_check() {
   else
     printf 'Skipped git diff --check because %s is not a git checkout.\n' "$ROOT"
   fi
+}
+
+package_manifest_field() {
+  local field="$1"
+  node -e "const fs = require('fs'); const manifest = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); const value = manifest[process.argv[2]]; if (value === undefined) process.exit(1); if (typeof value === 'string') { process.stdout.write(value); } else { process.stdout.write(JSON.stringify(value)); }" "$ROOT/package.json" "$field"
+}
+
+check_semver_greater() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+
+
+def parse(version: str) -> tuple[list[int], str]:
+    normalized = version.strip().lstrip("v")
+    core, _, prerelease = normalized.partition("-")
+    parts = [int(part) if part.isdigit() else 0 for part in core.split(".") if part]
+    return parts, prerelease
+
+
+local_parts, local_pre = parse(sys.argv[1])
+remote_parts, remote_pre = parse(sys.argv[2])
+width = max(len(local_parts), len(remote_parts), 3)
+local_parts.extend([0] * (width - len(local_parts)))
+remote_parts.extend([0] * (width - len(remote_parts)))
+
+if local_parts > remote_parts:
+    raise SystemExit(0)
+if local_parts < remote_parts:
+    raise SystemExit(1)
+if local_pre and not remote_pre:
+    raise SystemExit(1)
+if not local_pre and remote_pre:
+    raise SystemExit(0)
+if local_pre > remote_pre:
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+verify_npm_pack_payload() {
+  local platform_dir="$1"
+  python3 -c 'import json, sys
+platform_dir = sys.argv[1]
+payload = json.load(sys.stdin)
+entries = payload if isinstance(payload, list) else [payload]
+if not entries:
+    print("npm pack output was empty", file=sys.stderr)
+    raise SystemExit(1)
+files = {entry.get("path") for entry in entries[0].get("files", [])}
+expected = [
+    f"npm/native/{platform_dir}/dam",
+    f"npm/native/{platform_dir}/damctl",
+    f"npm/native/{platform_dir}/dam-web",
+    f"npm/native/{platform_dir}/dam-proxy",
+    f"npm/native/{platform_dir}/dam-mcp",
+    f"npm/native/{platform_dir}/dam-tray",
+]
+missing = [path for path in expected if path not in files]
+if missing:
+    print("missing staged native package files:", file=sys.stderr)
+    for path in missing:
+        print(path, file=sys.stderr)
+    raise SystemExit(1)
+print(entries[0].get("filename", ""))' "$platform_dir"
+}
+
+cmd_agent_npm_readiness() {
+  local package_name local_version registry_url platform_dir doctor_output pack_output pack_filename
+  local registry_version owners whoami_output blockers=()
+
+  cmd_npm_native
+
+  package_name="$(package_manifest_field name)"
+  local_version="$(package_manifest_field version)"
+  registry_url="$(npm config get registry)"
+  platform_dir="$(node -p "process.platform + '-' + process.arch")"
+
+  if ! doctor_output="$(node "$ROOT/npm/bin/dam.js" package-doctor --json)"; then
+    printf '%s\n' "$doctor_output"
+    echo "npm package-doctor failed" >&2
+    exit 1
+  fi
+
+  if ! pack_output="$(npm pack --dry-run --ignore-scripts --json)"; then
+    printf '%s\n' "$pack_output"
+    echo "npm pack --dry-run failed" >&2
+    exit 1
+  fi
+
+  if ! pack_filename="$(printf '%s' "$pack_output" | verify_npm_pack_payload "$platform_dir")"; then
+    blockers+=("npm pack payload is missing one or more staged native binaries for $platform_dir")
+  fi
+
+  registry_version="unknown"
+  if registry_version="$(npm view "$package_name" version --json 2>/dev/null | python3 -c 'import json, sys
+payload = json.load(sys.stdin)
+if isinstance(payload, str):
+    print(payload)
+else:
+    print(json.dumps(payload))')"; then
+    if [[ -n "$registry_version" ]] && ! check_semver_greater "$local_version" "$registry_version"; then
+      blockers+=("local package version $local_version is not greater than published npm version $registry_version")
+    fi
+  else
+    registry_version="unavailable"
+    blockers+=("unable to read current npm registry version for $package_name")
+  fi
+
+  owners="$(npm owner ls "$package_name" 2>/dev/null || true)"
+  if [[ -z "$owners" ]]; then
+    owners="unavailable"
+  fi
+
+  if whoami_output="$(npm whoami 2>&1)"; then
+    :
+  else
+    whoami_output="missing"
+    blockers+=("npm publish auth is not configured on this machine; Alexy must run npm adduser or configure a publish token for $package_name")
+  fi
+
+  printf 'DAM agent npm readiness\n'
+  printf 'package: %s\n' "$package_name"
+  printf 'local_version: %s\n' "$local_version"
+  printf 'registry: %s\n' "$registry_url"
+  printf 'registry_version: %s\n' "$registry_version"
+  printf 'platform_dir: %s\n' "$platform_dir"
+  printf 'package_doctor_state: ready\n'
+  printf 'pack_file: %s\n' "$pack_filename"
+  printf 'pack_native_files_present: %s\n' "$( [[ -n "$pack_filename" ]] && printf yes || printf no )"
+  printf 'npm_owners: %s\n' "$owners"
+  printf 'npm_auth: %s\n' "$whoami_output"
+
+  if (( ${#blockers[@]} == 0 )); then
+    printf 'blockers: none\n'
+    return 0
+  fi
+
+  printf 'blockers:\n'
+  local blocker
+  for blocker in "${blockers[@]}"; do
+    printf '  - %s\n' "$blocker"
+  done
+  return 1
 }
 
 cmd_detector_bench() {
@@ -639,6 +784,7 @@ case "$COMMAND" in
   release-macos) cmd_release_macos ;;
   deploy-local) cmd_deploy_local ;;
   agent-check) cmd_agent_check ;;
+  agent-npm-readiness) cmd_agent_npm_readiness ;;
   detector-bench) cmd_detector_bench ;;
   agent-protection-smoke) cmd_agent_protection_smoke ;;
   agent-recovery-smoke) cmd_agent_recovery_smoke ;;

--- a/scripts/dam-build.sh
+++ b/scripts/dam-build.sh
@@ -376,7 +376,7 @@ else:
     :
   else
     whoami_output="missing"
-    blockers+=("npm publish auth is not configured on this machine; Alexy must run npm adduser or configure a publish token for $package_name")
+    blockers+=("npm publish auth is not configured on this machine; run npm adduser or configure a publish token for $package_name")
   fi
 
   printf 'DAM agent npm readiness\n'

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -512,6 +512,111 @@ JSON
             )
             self.assertIn("npm publish auth is not configured on this machine", result.stdout)
 
+    def test_agent_npm_readiness_reports_blocker_when_pack_payload_missing_native_binaries(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            bin_dir = temp_path / "bin"
+            bin_dir.mkdir()
+
+            real_node = shutil.which("node")
+            self.assertIsNotNone(real_node)
+
+            cargo = bin_dir / "cargo"
+            cargo.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+            cargo.chmod(0o755)
+
+            node = bin_dir / "node"
+            node.write_text(
+                textwrap.dedent(
+                    f"""
+                    #!/usr/bin/env sh
+                    if [ "$1" = "-p" ] && [ "$2" = "process.platform + '-' + process.arch" ]; then
+                      printf 'linux-x64\\n'
+                      exit 0
+                    fi
+                    exec {real_node} "$@"
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            node.chmod(0o755)
+
+            # Pack output omits the native binaries to exercise the missing-files blocker.
+            npm = bin_dir / "npm"
+            npm.write_text(
+                textwrap.dedent(
+                    """
+                    #!/usr/bin/env sh
+                    if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "registry" ]; then
+                      printf 'https://registry.npmjs.org/\n'
+                      exit 0
+                    fi
+                    if [ "$1" = "view" ] && [ "$2" = "@rpblc/dam" ] && [ "$3" = "version" ] && [ "$4" = "--json" ]; then
+                      printf '"0.0.1"\n'
+                      exit 0
+                    fi
+                    if [ "$1" = "owner" ] && [ "$2" = "ls" ] && [ "$3" = "@rpblc/dam" ]; then
+                      printf 'rpblc-alexy <contact@rpblc.com>\n'
+                      exit 0
+                    fi
+                    if [ "$1" = "whoami" ]; then
+                      printf 'rpblc-alexy\n'
+                      exit 0
+                    fi
+                    if [ "$1" = "pack" ]; then
+                      cat <<'JSON'
+[{"id":"@rpblc/dam@0.1.0","name":"@rpblc/dam","version":"0.1.0","filename":"rpblc-dam-0.1.0.tgz","files":[{"path":"README.md"},{"path":"npm/bin/dam.js"}]}]
+JSON
+                      exit 0
+                    fi
+                    printf 'unexpected npm invocation: %s\n' "$*" >&2
+                    exit 1
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            npm.chmod(0o755)
+
+            release_dir = ROOT / "target" / "release"
+            release_dir.mkdir(parents=True, exist_ok=True)
+            created_release_files = []
+            for name in ["dam", "damctl", "dam-web", "dam-proxy", "dam-mcp", "dam-tray"]:
+                binary = release_dir / name
+                if not binary.exists():
+                    binary.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+                    binary.chmod(0o755)
+                    created_release_files.append(binary)
+
+            staged_dir = ROOT / "npm" / "native" / "linux-x64"
+            if staged_dir.exists():
+                shutil.rmtree(staged_dir)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+
+            try:
+                result = subprocess.run(
+                    [str(BUILD_SCRIPT), "agent-npm-readiness"],
+                    cwd=ROOT,
+                    env=env,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            finally:
+                if staged_dir.exists():
+                    shutil.rmtree(staged_dir)
+                for binary in created_release_files:
+                    if binary.exists():
+                        binary.unlink()
+
+            self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+            self.assertIn("pack_native_files_present: no", result.stdout)
+            self.assertIn(
+                "npm pack payload is missing one or more staged native binaries for linux-x64",
+                result.stdout,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -400,6 +401,116 @@ class DamBuildScriptTests(unittest.TestCase):
             self.assertIn(str(binary_path), argv)
             self.assertIn("--no-build", argv)
             self.assertIn("--keep-temp", argv)
+
+    def test_agent_npm_readiness_reports_publish_blockers_after_local_pack_validation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            bin_dir = temp_path / "bin"
+            bin_dir.mkdir()
+
+            real_node = shutil.which("node")
+            self.assertIsNotNone(real_node)
+
+            cargo = bin_dir / "cargo"
+            cargo.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+            cargo.chmod(0o755)
+
+            node = bin_dir / "node"
+            node.write_text(
+                textwrap.dedent(
+                    f"""
+                    #!/usr/bin/env sh
+                    if [ "$1" = "-p" ] && [ "$2" = "process.platform + '-' + process.arch" ]; then
+                      printf 'linux-x64\\n'
+                      exit 0
+                    fi
+                    exec {real_node} "$@"
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            node.chmod(0o755)
+
+            npm = bin_dir / "npm"
+            npm.write_text(
+                textwrap.dedent(
+                    """
+                    #!/usr/bin/env sh
+                    if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "registry" ]; then
+                      printf 'https://registry.npmjs.org/\n'
+                      exit 0
+                    fi
+                    if [ "$1" = "view" ] && [ "$2" = "@rpblc/dam" ] && [ "$3" = "version" ] && [ "$4" = "--json" ]; then
+                      printf '"0.3.1"\n'
+                      exit 0
+                    fi
+                    if [ "$1" = "owner" ] && [ "$2" = "ls" ] && [ "$3" = "@rpblc/dam" ]; then
+                      printf 'rpblc-alexy <contact@rpblc.com>\n'
+                      exit 0
+                    fi
+                    if [ "$1" = "whoami" ]; then
+                      printf 'npm error code ENEEDAUTH\n' >&2
+                      printf 'npm error need auth This command requires you to be logged in.\n' >&2
+                      exit 1
+                    fi
+                    if [ "$1" = "pack" ]; then
+                      cat <<'JSON'
+[{"id":"@rpblc/dam@0.1.0","name":"@rpblc/dam","version":"0.1.0","filename":"rpblc-dam-0.1.0.tgz","files":[{"path":"README.md"},{"path":"npm/bin/dam.js"},{"path":"npm/bin/damctl.js"},{"path":"npm/bin/dam-web.js"},{"path":"npm/bin/dam-proxy.js"},{"path":"npm/bin/dam-mcp.js"},{"path":"npm/bin/dam-tray.js"},{"path":"npm/native/linux-x64/dam"},{"path":"npm/native/linux-x64/damctl"},{"path":"npm/native/linux-x64/dam-web"},{"path":"npm/native/linux-x64/dam-proxy"},{"path":"npm/native/linux-x64/dam-mcp"},{"path":"npm/native/linux-x64/dam-tray"}]}]
+JSON
+                      exit 0
+                    fi
+                    printf 'unexpected npm invocation: %s\n' "$*" >&2
+                    exit 1
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            npm.chmod(0o755)
+
+            release_dir = ROOT / "target" / "release"
+            release_dir.mkdir(parents=True, exist_ok=True)
+            created_release_files = []
+            for name in ["dam", "damctl", "dam-web", "dam-proxy", "dam-mcp", "dam-tray"]:
+                binary = release_dir / name
+                if not binary.exists():
+                    binary.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+                    binary.chmod(0o755)
+                    created_release_files.append(binary)
+
+            staged_dir = ROOT / "npm" / "native" / "linux-x64"
+            if staged_dir.exists():
+                shutil.rmtree(staged_dir)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+
+            try:
+                result = subprocess.run(
+                    [str(BUILD_SCRIPT), "agent-npm-readiness"],
+                    cwd=ROOT,
+                    env=env,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            finally:
+                if staged_dir.exists():
+                    shutil.rmtree(staged_dir)
+                for binary in created_release_files:
+                    if binary.exists():
+                        binary.unlink()
+
+            self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+            self.assertIn("DAM agent npm readiness", result.stdout)
+            self.assertIn("local_version: 0.1.0", result.stdout)
+            self.assertIn("registry_version: 0.3.1", result.stdout)
+            self.assertIn("npm_auth: missing", result.stdout)
+            self.assertIn("pack_native_files_present: yes", result.stdout)
+            self.assertIn(
+                "local package version 0.1.0 is not greater than published npm version 0.3.1",
+                result.stdout,
+            )
+            self.assertIn("npm publish auth is not configured on this machine", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What I did
- Added `scripts/dam-build.sh agent-npm-readiness` to stage current-platform npm native binaries, validate the package payload, and report publish blockers without publishing.
- Added a focused regression test in `tests/test_dam_build_script.py` covering the new command's pack validation plus registry/auth blocker reporting.
- Updated `docs/build-release.md` and `docs/dam.md` so the maintainer-facing npm readiness contract matches the implementation.

## Why I did it
- Backlog issue #34 asked for a concrete local npm installability artifact instead of roadmap text alone.
- DAM already had `npm pack` smoke coverage, but it did not answer the practical release question: are the staged native binaries actually included, and what still blocks a publish?
- This command turns that question into one local/read-only probe and makes Alexy-owned publish blockers explicit.

## How I did it
- Reused `cmd_npm_native` to stage the native binaries for the current platform.
- Added pack-payload verification so `npm pack --dry-run --ignore-scripts --json` must include the expected staged binaries for the current `platform-arch` directory.
- Queried the npm registry owner/version and local npm auth state, then failed closed when the local version is not publishable or the machine lacks publish auth.
- Kept the command read-only: no publish, no package ownership mutation, no routing/trust mutation, no repo-stored credentials.

## Branch / PR
- Branch: `feat/npm-readiness-check`
- Companion Architecture PR: https://github.com/RPBLC-hq/Architecture/pull/44
- Refs #34

## Verification
- `python3 -m unittest tests.test_dam_build_script`
- `scripts/dam-build.sh agent-npm-readiness`
- `scripts/dam-build.sh agent-check`

### `agent-npm-readiness` result
- `registry_version: 0.3.1`
- `npm_owners: rpblc-alexy <contact@rpblc.com>`
- `pack_native_files_present: yes`
- Blocker: local `package.json` version is `0.1.0`, which is not greater than the published npm version.
- Blocker: this machine is not logged into npm (`npm whoami` returned `ENEEDAUTH`).

## Risk / Notes
- No protection-path behavior changed, so I did not run `agent-protection-smoke`.
- Release/install contract changed, so this PR should receive current-head QA plus Copilot/Codex review.
- Alexy action request: before a real publish, bump the package version above `0.3.1` and configure npm publish auth on the release machine (interactive `npm adduser` or an automation token for `@rpblc/dam`).
