### PR TITLE
fix: hide MCP actor metadata from direct-access status

### DIFF
--- a/crates/dam-mcp/src/direct_access.rs
+++ b/crates/dam-mcp/src/direct_access.rs
@@ -285,7 +285,6 @@ fn direct_access_request_to_json(entry: &dam_consent::DirectAccessRequest) -> Va
         "status": entry.status.tag(),
         "kind": entry.kind.tag(),
         "vault_key": entry.vault_key,
-        "requesting_actor": entry.requesting_actor,
         "purpose": entry.purpose,
         "reason": entry.reason,
         "decision_reason": entry.decision_reason,

--- a/crates/dam-mcp/src/main_tests.rs
+++ b/crates/dam-mcp/src/main_tests.rs
@@ -131,6 +131,7 @@ fn direct_access_request_status_and_resolve_flow() {
     let request: Value = serde_json::from_str(&request_json).unwrap();
     let request_id = request["request_id"].as_str().unwrap().to_string();
     assert_eq!(request["status"], "pending");
+    assert_eq!(request["requesting_actor"], Value::Null);
 
     let status_json = call_tool_with_actor(
         &config,
@@ -141,6 +142,14 @@ fn direct_access_request_status_and_resolve_flow() {
     .unwrap();
     let status: Value = serde_json::from_str(&status_json).unwrap();
     assert_eq!(status["status"], "pending");
+    assert_eq!(status["requesting_actor"], Value::Null);
+
+    let list_json =
+        call_tool_with_actor(&config, "dam_consent_list", &json!({}), Some(actor.clone())).unwrap();
+    let list: Value = serde_json::from_str(&list_json).unwrap();
+    let listed_request = &list["direct_access_requests"][0];
+    assert_eq!(listed_request["request_id"], request_id);
+    assert_eq!(listed_request["requesting_actor"], Value::Null);
 
     let store = dam_consent::ConsentStore::open(&consent_path).unwrap();
     store
@@ -158,6 +167,7 @@ fn direct_access_request_status_and_resolve_flow() {
     let resolved: Value = serde_json::from_str(&resolve_json).unwrap();
     assert_eq!(resolved["value"], "alice@example.test");
     assert_eq!(resolved["request"]["status"], "consumed");
+    assert_eq!(resolved["request"]["requesting_actor"], Value::Null);
 
     let denied_json = call_tool_with_actor(
         &config,

--- a/docs/dam-mcp.md
+++ b/docs/dam-mcp.md
@@ -90,7 +90,7 @@ Actor binding comes from `DAM_MCP_ACTOR_LABEL` and/or `DAM_MCP_ACTOR_ID`:
 - if only `DAM_MCP_ACTOR_ID` is set, DAM accepts it and uses that same value as the display label;
 - if only `DAM_MCP_ACTOR_LABEL` is set, DAM derives a stable local hashed actor ID from the trimmed label.
 
-`dam_consent_request_status` returns the current non-sensitive state for a `request_id` or `grant_id`.
+`dam_consent_request_status` returns the current non-sensitive state for a `request_id` or `grant_id`. MCP status/list/resolve metadata intentionally omit actor binding material (`requesting_actor`, derived actor IDs, fingerprints) so one local MCP client cannot learn enough from another client's pending request to impersonate and consume a grant.
 
 `dam_resolve_if_consented` returns a raw value only when all of these are true:
 


### PR DESCRIPTION
## What I did
- removed `requesting_actor` from MCP direct-access request/list/status/resolve metadata
- documented that MCP metadata intentionally omits actor-binding material so one local MCP client cannot learn enough from another client's pending request to impersonate and consume a grant
- added focused `dam-mcp` regressions covering request, list, status, and resolve responses

## Why I did it
PR #121 merged the bounded MCP value-access consent slice into `main`, but a current-head review follow-up found that the MCP metadata still exposed enough actor-binding material for another local MCP client to learn from a pending request and potentially impersonate the approved actor. This follow-up hardens the local metadata surface without changing the approved direct-access contract or proxy/interception behavior.

## How I did it
- removed `requesting_actor` from `direct_access_request_to_json` in `crates/dam-mcp/src/direct_access.rs`
- extended `direct_access_request_status_and_resolve_flow` so request, list, status, and resolve metadata all assert `requesting_actor` is omitted/null while the real bound actor can still resolve successfully
- updated `docs/dam-mcp.md` to state explicitly that MCP status/list/resolve metadata omits actor-binding material

## Test plan
- `cargo test -q -p dam-mcp direct_access_request_status_and_resolve_flow`
- `cargo test -q -p dam-mcp status_tool_available_when_mcp_write_disabled`
- `cargo test -q -p dam-mcp --bin dam-mcp`
- `scripts/dam-build.sh agent-check`
- `git diff --check`

## Current-head verification
On head `9ce3fb94ec775f9b020229bd4eaed6f573a9414e`:
- `cargo test -q -p dam-mcp direct_access_request_status_and_resolve_flow` → 1 passed
- `cargo test -q -p dam-mcp status_tool_available_when_mcp_write_disabled` → 1 passed
- `cargo test -q -p dam-mcp --bin dam-mcp` → 10 passed
- `scripts/dam-build.sh agent-check` → passed (`npm ci`, UI build, npm smoke, `npm pack --dry-run --ignore-scripts`, `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, and `git diff --check`)
- `git diff --check` → passed

## Notes
- Follow-up to merged PR #121; no Architecture companion PR was needed because the accepted Architecture consent/MCP contract did not change.
- I did **not** run `agent-protection-smoke` because this change stays in local consent/MCP state handling and metadata shape, and does not change proxy/interception behavior.

Refs #121
