### PR TITLE
test: guard diagnostics export against raw leaks

### DIFF
--- a/crates/dam-diagnostics/src/lib_tests.rs
+++ b/crates/dam-diagnostics/src/lib_tests.rs
@@ -781,18 +781,25 @@ async fn doctor_reports_config_required_route_as_degraded() {
     }));
 }
 
+fn synthetic_api_key() -> String {
+    format!("KEY_{}", "A".repeat(24))
+}
+
 #[tokio::test]
 async fn doctor_redacts_supported_sensitive_values_from_proxy_health_surfaces() {
+    let api_key = synthetic_api_key();
     let proxy_url = spawn_health(dam_api::ProxyReport {
         operation_id: None,
         target: Some("test".to_string()),
         upstream: Some("https://api.example.test".to_string()),
         state: dam_api::ProxyState::Protected,
-        message: "last protected request saw alice@example.com and 123-45-6789".to_string(),
+        message: format!(
+            "last protected request saw alice@example.com and 123-45-6789 with api_key={api_key}"
+        ),
         diagnostics: vec![dam_api::Diagnostic::new(
             dam_api::DiagnosticSeverity::Warning,
             "proxy_trace",
-            "upstream echoed alice@example.com and 123-45-6789",
+            format!("upstream echoed alice@example.com and 123-45-6789 with api_key={api_key}"),
         )],
     })
     .await;
@@ -810,8 +817,56 @@ async fn doctor_redacts_supported_sensitive_values_from_proxy_health_surfaces() 
 
     assert!(!json.contains("alice@example.com"));
     assert!(!json.contains("123-45-6789"));
+    assert!(!json.contains(&api_key));
     assert!(json.contains("[email]"));
     assert!(json.contains("[ssn]"));
+    assert!(json.contains("[api_key]"));
+}
+
+#[tokio::test]
+async fn setup_diagnostics_export_redacts_supported_sensitive_values_from_proxy_health_surfaces() {
+    let api_key = synthetic_api_key();
+    let proxy_url = spawn_health(dam_api::ProxyReport {
+        operation_id: None,
+        target: Some("test".to_string()),
+        upstream: Some("https://api.example.test".to_string()),
+        state: dam_api::ProxyState::Protected,
+        message: format!(
+            "last protected request saw alice@example.com and 123-45-6789 with api_key={api_key}"
+        ),
+        diagnostics: vec![dam_api::Diagnostic::new(
+            dam_api::DiagnosticSeverity::Warning,
+            "proxy_trace",
+            format!("upstream echoed alice@example.com and 123-45-6789 with api_key={api_key}"),
+        )],
+    })
+    .await;
+    let config = proxy_config("https://api.example.test", "openai-compatible");
+    let dir = tempfile::tempdir().unwrap();
+
+    let export = setup_diagnostics_export(
+        &config,
+        &DoctorOptions {
+            proxy_url: Some(proxy_url),
+            state_dir: Some(dir.path().join("state")),
+            ..DoctorOptions::default()
+        },
+        &SetupPlanOptions {
+            state_dir: Some(dir.path().join("state")),
+            proxy_url: Some("http://127.0.0.1:7828".to_string()),
+            ..SetupPlanOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+    let json = serde_json::to_string(&export).unwrap();
+
+    assert!(!json.contains("alice@example.com"));
+    assert!(!json.contains("123-45-6789"));
+    assert!(!json.contains(&api_key));
+    assert!(json.contains("[email]"));
+    assert!(json.contains("[ssn]"));
+    assert!(json.contains("[api_key]"));
 }
 
 fn test_daemon_state(pid: u32) -> dam_daemon::DaemonState {

--- a/crates/dam-diagnostics/src/lib_tests.rs
+++ b/crates/dam-diagnostics/src/lib_tests.rs
@@ -861,6 +861,15 @@ async fn setup_diagnostics_export_redacts_supported_sensitive_values_from_proxy_
     .unwrap();
     let json = serde_json::to_string(&export).unwrap();
 
+    assert!(export.doctor.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "proxy_trace"
+            && diagnostic.message.contains("[email]")
+            && diagnostic.message.contains("[ssn]")
+            && diagnostic.message.contains("[api_key]")
+            && !diagnostic.message.contains("alice@example.com")
+            && !diagnostic.message.contains("123-45-6789")
+            && !diagnostic.message.contains(&api_key)
+    }));
     assert!(!json.contains("alice@example.com"));
     assert!(!json.contains("123-45-6789"));
     assert!(!json.contains(&api_key));


### PR DESCRIPTION
## What I did
- added an explicit `setup_diagnostics_export_redacts_supported_sensitive_values_from_proxy_health_surfaces()` regression so the exported diagnostics surface is covered directly, not only the base `doctor_report` helper
- kept the existing doctor redaction test and widened the export test to assert `export.doctor.diagnostics` contains the redacted `proxy_trace` diagnostic and no raw synthetic email/SSN/API-key values

## Why I did it
- a current-head review comment noted the export path could still be under-asserted even though the diagnostics data were being sanitized
- Architecture issue #63 requires the diagnostics / doctor / export surfaces to fail closed on raw protected values while preserving useful troubleshooting metadata

## How I did it
- reused the same synthetic proxy health fixture for both `doctor_report` and `setup_diagnostics_export`
- asserted both the nested diagnostics object and the serialized export JSON contain `[email]`, `[ssn]`, and `[api_key]` markers but not the raw synthetic values
- re-ran `cargo test -q -p dam-diagnostics`, `scripts/dam-build.sh agent-check`, and `git diff --check` on current head `21db6973a0d4d1a2f70ef9d2ef0f7ec05a1c2d0a`

## Summary
- DAM-only follow-up that tightens diagnostics/export regression coverage against the already-accepted raw-leak contract
- no Architecture companion PR was needed because the contract did not change

## Test Plan
- `cargo test -q -p dam-diagnostics`
- `scripts/dam-build.sh agent-check`
- `git diff --check`
- `agent-protection-smoke` not run because this change is diagnostics-only and does not alter proxy/runtime protection behavior

Closes RPBLC-hq/Architecture#63