### PR TITLE
test: cover setup status label matrix

### DIFF
--- a/crates/dam-web/ui/src/features/connect/status-summary.test.ts
+++ b/crates/dam-web/ui/src/features/connect/status-summary.test.ts
@@ -83,6 +83,66 @@ test('maps connected-setup milestone before trust completion to connected copy',
   assert.equal(connectNavLabelKey(connectView), 'nav.connecting')
 })
 
+test('maps waiting-for-reboot setup to connecting copy', () => {
+  const connectView = view({
+    setup_plan: {
+      current_step_id: 'ne_reboot',
+      steps: [
+        step({ id: 'ne_enable', label: 'Enable network extension', state: 'done', detail: 'enabled' }),
+        step({ id: 'ne_reboot', label: 'Restart macOS', state: 'blocked', detail: 'waiting_for_reboot' }),
+      ],
+    },
+  })
+
+  assert.equal(connectStatusMessageKey(connectView), 'connect.summary.waiting_for_reboot')
+  assert.equal(connectNavLabelKey(connectView), 'nav.connecting')
+})
+
+test('maps failed setup to repair-needed copy', () => {
+  const connectView = view({
+    state: 'degraded',
+    message: 'degraded',
+    setup_plan: {
+      current_step_id: 'ne_start',
+      steps: [
+        step({
+          id: 'ne_start',
+          label: 'Enable protection layer',
+          state: 'failed',
+          detail: 'failed',
+          reason_code: 'setup_step_failed',
+        }),
+      ],
+    },
+  })
+
+  assert.equal(connectStatusMessageKey(connectView), 'connect.summary.failed')
+  assert.equal(connectNavLabelKey(connectView), 'nav.repairNeeded')
+})
+
+test('maps generic needs-setup state without setup progress to setup-needed copy', () => {
+  const connectView = view({
+    setup_plan: {
+      current_step_id: 'setup',
+      steps: [],
+    },
+  })
+
+  assert.equal(connectStatusMessageKey(connectView), 'connect.setupStatus')
+  assert.equal(connectNavLabelKey(connectView), 'nav.setupNeeded')
+})
+
+test('maps disconnected state to the off brand-bar label', () => {
+  const connectView = view({
+    state: 'disconnected',
+    message: 'disconnected',
+    setup_plan: null,
+  })
+
+  assert.equal(connectStatusMessageKey(connectView), 'connect.disconnectedLede')
+  assert.equal(connectNavLabelKey(connectView), 'nav.off')
+})
+
 test('maps rolled-back setup to repair-needed copy', () => {
   const connectView = view({
     state: 'degraded',


### PR DESCRIPTION
## What I did
- Added focused regression coverage for DAM Connect status-summary mapping across the remaining installed-setup label states.
- Covered `waiting_for_reboot`, failed/repair-needed, generic setup-needed, and disconnected/off cases in `crates/dam-web/ui/src/features/connect/status-summary.test.ts`.
- Kept this as a DAM-only PR because the accepted setup-status contract and docs were already correct; this change tightens implementation proof rather than changing visible behavior or shared contracts.

## Why I did it
- Architecture issue #67 requires installed/web/tray setup status to stay unambiguous across requested, approval-needed, connecting, repair-needed, setup-needed, and disconnected states.
- The current implementation and DAM/Architecture docs already encode that matrix, but the focused test coverage was incomplete for several important fallback and recovery states.
- Locking those states down reduces regression risk in the shared brand bar and Connect page without expanding scope into a broader UX redesign.

## How I did it
- Extended the existing direct Node test for `status-summary.ts` to cover the missing setup-detail/state combinations.
- Re-ran the focused UI typecheck and full DAM `agent-check` suite on the pushed head.
- Did not run `agent-protection-smoke` because proxy/interception behavior did not change.

## Issue
- Closes #67

## Test plan
- `node --test crates/dam-web/ui/src/features/connect/status-summary.test.ts`
- `npm --prefix crates/dam-web/ui run typecheck`
- `scripts/dam-build.sh agent-check`
- `git diff --check`

## Architecture / docs
- No Architecture companion PR was needed.
- No docs change was needed because `docs/dam-web.md` and `Architecture/dam/web/specs/connect-tab.md` already describe the accepted label mapping this PR now covers more completely.

## Risk / boundaries
- DAM-only, test-only follow-up.
- No host network/proxy/trust mutation.
- Synthetic/local verification only.
