### PR TITLE
chore: prepare npm package version 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpblc/dam",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "description": "Local DAM launcher and native binary shims.",
   "license": "Apache-2.0",
   "bin": {

--- a/tests/test_dam_build_script.py
+++ b/tests/test_dam_build_script.py
@@ -856,7 +856,7 @@ class DamBuildScriptTests(unittest.TestCase):
                       exit 0
                     fi
                     if [ "$1" = "view" ] && [ "$2" = "@rpblc/dam" ] && [ "$3" = "version" ] && [ "$4" = "--json" ]; then
-                      printf '"0.3.1"\n'
+                      printf '"0.3.3"\n'
                       exit 0
                     fi
                     if [ "$1" = "owner" ] && [ "$2" = "ls" ] && [ "$3" = "@rpblc/dam" ]; then
@@ -870,7 +870,7 @@ class DamBuildScriptTests(unittest.TestCase):
                     fi
                     if [ "$1" = "pack" ]; then
                       cat <<'JSON'
-[{"id":"@rpblc/dam@0.1.0","name":"@rpblc/dam","version":"0.1.0","filename":"rpblc-dam-0.1.0.tgz","files":[{"path":"README.md"},{"path":"npm/bin/dam.js"},{"path":"npm/bin/damctl.js"},{"path":"npm/bin/dam-web.js"},{"path":"npm/bin/dam-proxy.js"},{"path":"npm/bin/dam-mcp.js"},{"path":"npm/bin/dam-tray.js"},{"path":"npm/native/linux-x64/dam"},{"path":"npm/native/linux-x64/damctl"},{"path":"npm/native/linux-x64/dam-web"},{"path":"npm/native/linux-x64/dam-proxy"},{"path":"npm/native/linux-x64/dam-mcp"},{"path":"npm/native/linux-x64/dam-tray"}]}]
+[{"id":"@rpblc/dam@0.3.2","name":"@rpblc/dam","version":"0.3.2","filename":"rpblc-dam-0.3.2.tgz","files":[{"path":"README.md"},{"path":"npm/bin/dam.js"},{"path":"npm/bin/damctl.js"},{"path":"npm/bin/dam-web.js"},{"path":"npm/bin/dam-proxy.js"},{"path":"npm/bin/dam-mcp.js"},{"path":"npm/bin/dam-tray.js"},{"path":"npm/native/linux-x64/dam"},{"path":"npm/native/linux-x64/damctl"},{"path":"npm/native/linux-x64/dam-web"},{"path":"npm/native/linux-x64/dam-proxy"},{"path":"npm/native/linux-x64/dam-mcp"},{"path":"npm/native/linux-x64/dam-tray"}]}]
 JSON
                       exit 0
                     fi
@@ -917,12 +917,12 @@ JSON
 
             self.assertEqual(1, result.returncode, result.stdout + result.stderr)
             self.assertIn("DAM agent npm readiness", result.stdout)
-            self.assertIn("local_version: 0.1.0", result.stdout)
-            self.assertIn("registry_version: 0.3.1", result.stdout)
+            self.assertIn("local_version: 0.3.2", result.stdout)
+            self.assertIn("registry_version: 0.3.3", result.stdout)
             self.assertIn("npm_auth: missing", result.stdout)
             self.assertIn("pack_native_files_present: yes", result.stdout)
             self.assertIn(
-                "local package version 0.1.0 is not greater than published npm version 0.3.1",
+                "local package version 0.3.2 is not greater than published npm version 0.3.3",
                 result.stdout,
             )
             self.assertIn("npm publish auth is not configured on this machine", result.stdout)


### PR DESCRIPTION
What I did
- Verified the live npm registry version before choosing a local version: `npm view @rpblc/dam version --json` returned `"0.3.1"`.
- Bumped the npm package manifest from `0.1.0` to `0.3.2`, the smallest patch version greater than the currently published `0.3.1`.
- Updated the build-script regression fixture so the stale-local-version blocker test still exercises a local-version-behind-registry case after the manifest bump.

Why I did it
- Architecture #94 split the agent-owned release-prep work away from Architecture #57's Alexy-owned npm auth/publish blocker.
- This keeps the next installability probe blocked only by publish credentials/authorization, not by stale local package version metadata.

How I did it
- Changed only `package.json` and `tests/test_dam_build_script.py`.
- Did not publish to npm.
- Did not configure credentials, create accounts/tokens, spend money, public-deploy, or mutate host routing/trust/network state.
- Did not run `agent-protection-smoke` because this PR changes npm package metadata/test fixtures only; runtime proxy/protection behavior is unchanged.

Verification
- `npm view @rpblc/dam version --json` → `"0.3.1"`
- `python3 -m unittest tests.test_dam_build_script.DamBuildScriptTests.test_agent_npm_readiness_reports_publish_blockers_after_local_pack_validation` → passed (`Ran 1 test`, `OK`)
- `npm run test` → passed (`npm package smoke passed`)
- `git diff --check` → passed (no output)
- `scripts/dam-build.sh agent-npm-readiness` → failed closed only on npm auth after staging native binaries and validating pack payload:
  - `local_version: 0.3.2`
  - `registry_version: 0.3.1`
  - `package_doctor_state: ready`
  - `pack_file: rpblc-dam-0.3.2.tgz`
  - `pack_native_files_present: yes`
  - `npm_owners: rpblc-alexy <contact@rpblc.com>`
  - `npm_auth: missing`
  - blocker: `npm publish auth is not configured on this machine; run npm adduser or configure a publish token for @rpblc/dam`
- `scripts/dam-build.sh agent-check` → passed (UI npm ci/build, npm smoke/pack, cargo fmt/clippy/tests, git diff check).

Publish/auth boundary
- Publishing remains out of scope and was not attempted.
- Architecture #57 remains the Alexy-owned blocker for npm auth/publish-token setup or release-machine selection.

Closes/advances
- Advances RPBLC-hq/Architecture#94.
- Leaves RPBLC-hq/Architecture#57 open/on-hold for npm publish auth.
