### PR TITLE
docs: clarify npm install release boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,21 @@ are still landing in slices. On those platforms, use source builds and explicit 
 experiments only; macOS-specific network mutation commands report `unsupported_platform`
 with fallback guidance instead of changing host networking.
 
-```bash
-npm install -g @rpblc/dam
-```
+The npm package name is reserved as `@rpblc/dam`, but the repository may be ahead of the
+published registry version. Use the source checkout for current development builds until
+the release issue confirms the npm package has been published from the current manifest
+version.
 
 From a source checkout:
 
 ```bash
 cargo build -p dam -p dam-web -p dam-tray
+```
+
+After a release is published, the global npm install path is:
+
+```bash
+npm install -g @rpblc/dam
 ```
 
 Per-platform native packages are staged — see [docs/build-release.md](docs/build-release.md).

--- a/docs/dam.md
+++ b/docs/dam.md
@@ -130,6 +130,8 @@ dam disconnect
 
 The npm package entry point is a small Node wrapper around native DAM binaries. It does not own protection behavior.
 
+The registry package is the future consumer install path, but release issue `RPBLC-hq/Architecture#57` tracks publish authorization and version state. If the repository manifest is ahead of the live registry version, use a source checkout for current behavior rather than assuming `npm install -g @rpblc/dam` installs the latest repository code.
+
 The package exposes shims for `dam`, `damctl`, `dam-web`, `dam-proxy`, `dam-mcp`, and `dam-tray`. `dam package-doctor --json` validates that the installed shims resolve to native binaries. `dam doctor --json` is forwarded to the native `dam` binary and reports local readiness. `scripts/dam-build.sh agent-npm-readiness` is the maintainer-side probe that stages current-platform native binaries, verifies the `npm pack --dry-run --ignore-scripts --json` payload, and reports registry/auth blockers without publishing.
 
 The previous one-shot `npx @rpblc/dam claude` and `npx @rpblc/dam codex --api` trial launchers have been removed because they depended on provider base-url rewriting. Use the installed `dam connect` / tray flow for protected traffic interception.


### PR DESCRIPTION
## Summary
- Stop presenting `npm install -g @rpblc/dam` as the current install path while the repo manifest is ahead of the live registry package.
- Point developers to source checkout builds until the npm release issue confirms publication from the current manifest version.
- Add the same boundary to the npm wrapper docs so future agents do not mistake local npm wrapper checks for registry install validation.

## Verification
- `git diff --check`
- `npm view @rpblc/dam version --json` -> `"0.3.1"`

## Notes
- No DAM smoke tests were run. This is a docs/product-boundary correction; it does not change runtime protection behavior.
- No npm install, publish, account/auth, host routing, trust, PAC, TUN, or firewall mutation was performed.